### PR TITLE
Guard agent invocation with `X_SUPERAGENT_API_KEY`

### DIFF
--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -3,9 +3,11 @@ import threading
 from queue import Queue
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security.api_key import APIKey
 from starlette.responses import StreamingResponse
 
 from app.lib.agents import Agent as AgentDefinition
+from app.lib.auth.api import get_api_key
 from app.lib.auth.prisma import JWTBearer, decodeJWT
 from app.lib.models.agents import Agent, PredictAgent
 from app.lib.prisma import prisma
@@ -92,7 +94,9 @@ async def delete_agent(agentId: str, token=Depends(JWTBearer())):
     name="Prompt agent",
     description="Invoke a specific agent",
 )
-async def run_agent(agentId: str, body: PredictAgent):
+async def run_agent(
+    agentId: str, body: PredictAgent, api_key: APIKey = Depends(get_api_key)
+):
     """Agent detail endpoint"""
     input = body.input
     has_streaming = body.has_streaming

--- a/app/lib/auth/api.py
+++ b/app/lib/auth/api.py
@@ -1,15 +1,20 @@
-from decouple import config
 from fastapi import HTTPException, Security
 from fastapi.security.api_key import APIKeyHeader
 from starlette.status import HTTP_403_FORBIDDEN
+
+from app.lib.prisma import prisma
 
 api_key_header = APIKeyHeader(name="X_SUPERAGENT_API_KEY", auto_error=False)
 
 
 async def get_api_key(api_key_header: str = Security(api_key_header)):
-    if api_key_header == config("API_KEY"):
+    try:
+        await prisma.apitoken.find_first(where={"token": api_key_header})
+
         return api_key_header
-    else:
+
+    except Exception as e:
+        print(e)
         raise HTTPException(
             status_code=HTTP_403_FORBIDDEN, detail="Could not validate API KEY"
         )

--- a/app/lib/auth/api.py
+++ b/app/lib/auth/api.py
@@ -14,7 +14,4 @@ async def get_api_key(api_key_header: str = Security(api_key_header)):
         return api_key_header
 
     except Exception as e:
-        print(e)
-        raise HTTPException(
-            status_code=HTTP_403_FORBIDDEN, detail="Could not validate API KEY"
-        )
+        raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail=e)


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

Guard agent invocation with `X_SUPERAGENT_API_KEY`

Fixes #20 

## Test plan

<!-- Include the steps to test your PR -->

The `/agents/id/predict` now requires the `X_SUPERAGENT_API_KEY`.
