### PR TITLE
Add support for Natural Language Agents

### DIFF
--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -140,6 +140,7 @@ async def run_agent(
         if has_streaming:
 
             async def on_llm_new_token(token) -> None:
+                print(token)
                 await data_queue.put(token)
 
             async def on_llm_end() -> None:

--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -26,11 +26,12 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
             }
         )
 
-        await upsert_document(
-            url=document_url,
-            type=document_type,
-            document_id=document.id,
-        )
+        if document_type == "TXT" or document_type == "PDF":
+            await upsert_document(
+                url=document_url,
+                type=document_type,
+                document_id=document.id,
+            )
 
         return {"success": True, "data": document}
 

--- a/app/lib/callbacks.py
+++ b/app/lib/callbacks.py
@@ -12,7 +12,7 @@ class StreamingCallbackHandler(AsyncCallbackHandler):
         self.on_llm_end_ = on_llm_end_
         self.on_chain_end_ = on_chain_end_
 
-    def on_llm_start(
+    async def on_llm_start(
         self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
     ) -> None:
         """Print out the prompts."""

--- a/app/lib/models/agent.py
+++ b/app/lib/models/agent.py
@@ -6,6 +6,7 @@ class Agent(BaseModel):
     type: str
     llm: dict = None
     has_memory: bool = False
+    documentId: str
 
 
 class PredictAgent(BaseModel):

--- a/app/lib/prompts.py
+++ b/app/lib/prompts.py
@@ -13,6 +13,20 @@ Human: {human_input}
 Assitant:
 """
 
+openapi_format_instructions = """Use the following format:
+
+Question: the input question you must answer
+Thought: you should always think about what to do
+Action: the action to take, should be one of [{tool_names}]
+Action Input: what to instruct the AI Action representative.
+Observation: The Agent's response
+... (this Thought/Action/Action Input/Observation can repeat N times)
+Thought: I now know the final answer. User can't see any of my observations, API responses, links, or tools.
+Final Answer: the final answer to the original input question in markdown.
+
+When responding with your Final Answer, use a conversational answer without referencing the API.
+"""
+
 default_chat_prompt = PromptTemplate(
     input_variables=["chat_history", "human_input"], template=default_chat_template
 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1064,14 +1064,14 @@ files = [
 
 [[package]]
 name = "langchain"
-version = "0.0.161"
+version = "0.0.177"
 description = "Building applications with LLMs through composability"
 category = "main"
 optional = false
 python-versions = ">=3.8.1,<4.0"
 files = [
-    {file = "langchain-0.0.161-py3-none-any.whl", hash = "sha256:b4f3a52d971c47268b3c44bf9dd2981836151e12c9d9cb0a11e7d2a07688e032"},
-    {file = "langchain-0.0.161.tar.gz", hash = "sha256:d05aaaee3e520f3993739adacbb926021de666a22620b1ece6b3f9065f35ae31"},
+    {file = "langchain-0.0.177-py3-none-any.whl", hash = "sha256:c9dab95210973aba8339a20ebcb3465fd6730628dd4ff9a6e23d6ad1c306d27d"},
+    {file = "langchain-0.0.177.tar.gz", hash = "sha256:3d8b59d31874ca4e014cf6730898acc384394a4da5d68ee8a29ac5b21deadaf8"},
 ]
 
 [package.dependencies]
@@ -1086,16 +1086,19 @@ PyYAML = ">=5.4.1"
 requests = ">=2,<3"
 SQLAlchemy = ">=1.4,<3"
 tenacity = ">=8.1.0,<9.0.0"
-tqdm = ">=4.48.0"
 
 [package.extras]
-all = ["O365 (>=2.0.26,<3.0.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "anthropic (>=0.2.6,<0.3.0)", "arxiv (>=1.4,<2.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "beautifulsoup4 (>=4,<5)", "clickhouse-connect (>=0.5.14,<0.6.0)", "cohere (>=3,<4)", "deeplake (>=3.3.0,<4.0.0)", "duckduckgo-search (>=2.8.6,<3.0.0)", "elasticsearch (>=8,<9)", "faiss-cpu (>=1,<2)", "google-api-python-client (==2.70.0)", "google-search-results (>=2,<3)", "gptcache (>=0.1.7)", "html2text (>=2020.1.16,<2021.0.0)", "huggingface_hub (>=0,<1)", "jina (>=3.14,<4.0)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "lancedb (>=0.1,<0.2)", "lark (>=1.1.5,<2.0.0)", "manifest-ml (>=0.0.1,<0.0.2)", "networkx (>=2.6.3,<3.0.0)", "nlpcloud (>=1,<2)", "nltk (>=3,<4)", "nomic (>=1.0.43,<2.0.0)", "openai (>=0,<1)", "opensearch-py (>=2.0.0,<3.0.0)", "pexpect (>=4.8.0,<5.0.0)", "pgvector (>=0.1.6,<0.2.0)", "pinecone-client (>=2,<3)", "pinecone-text (>=0.4.2,<0.5.0)", "psycopg2-binary (>=2.9.5,<3.0.0)", "pyowm (>=3.3.0,<4.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pytesseract (>=0.3.10,<0.4.0)", "pyvespa (>=0.33.0,<0.34.0)", "qdrant-client (>=1.1.2,<2.0.0)", "redis (>=4,<5)", "sentence-transformers (>=2,<3)", "spacy (>=3,<4)", "tensorflow-text (>=2.11.0,<3.0.0)", "tiktoken (>=0.3.2,<0.4.0)", "torch (>=1,<3)", "transformers (>=4,<5)", "weaviate-client (>=3,<4)", "wikipedia (>=1,<2)", "wolframalpha (==5.0.0)"]
+all = ["O365 (>=2.0.26,<3.0.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "anthropic (>=0.2.6,<0.3.0)", "arxiv (>=1.4,<2.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "beautifulsoup4 (>=4,<5)", "clickhouse-connect (>=0.5.14,<0.6.0)", "cohere (>=3,<4)", "deeplake (>=3.3.0,<4.0.0)", "docarray (>=0.31.0,<0.32.0)", "duckduckgo-search (>=2.8.6,<3.0.0)", "elasticsearch (>=8,<9)", "faiss-cpu (>=1,<2)", "google-api-python-client (==2.70.0)", "google-search-results (>=2,<3)", "gptcache (>=0.1.7)", "hnswlib (>=0.7.0,<0.8.0)", "html2text (>=2020.1.16,<2021.0.0)", "huggingface_hub (>=0,<1)", "jina (>=3.14,<4.0)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "lancedb (>=0.1,<0.2)", "lark (>=1.1.5,<2.0.0)", "lxml (>=4.9.2,<5.0.0)", "manifest-ml (>=0.0.1,<0.0.2)", "neo4j (>=5.8.1,<6.0.0)", "networkx (>=2.6.3,<3.0.0)", "nlpcloud (>=1,<2)", "nltk (>=3,<4)", "nomic (>=1.0.43,<2.0.0)", "openai (>=0,<1)", "opensearch-py (>=2.0.0,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pexpect (>=4.8.0,<5.0.0)", "pgvector (>=0.1.6,<0.2.0)", "pinecone-client (>=2,<3)", "pinecone-text (>=0.4.2,<0.5.0)", "protobuf (==3.19.6)", "psycopg2-binary (>=2.9.5,<3.0.0)", "pyowm (>=3.3.0,<4.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pytesseract (>=0.3.10,<0.4.0)", "pyvespa (>=0.33.0,<0.34.0)", "qdrant-client (>=1.1.2,<2.0.0)", "redis (>=4,<5)", "requests-toolbelt (>=1.0.0,<2.0.0)", "sentence-transformers (>=2,<3)", "spacy (>=3,<4)", "steamship (>=2.16.9,<3.0.0)", "tensorflow-text (>=2.11.0,<3.0.0)", "tiktoken (>=0.3.2,<0.4.0)", "torch (>=1,<3)", "transformers (>=4,<5)", "weaviate-client (>=3,<4)", "wikipedia (>=1,<2)", "wolframalpha (==5.0.0)"]
 azure = ["azure-core (>=1.26.4,<2.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "openai (>=0,<1)"]
 cohere = ["cohere (>=3,<4)"]
 embeddings = ["sentence-transformers (>=2,<3)"]
+extended-testing = ["atlassian-python-api (>=3.36.0,<4.0.0)", "beautifulsoup4 (>=4,<5)", "chardet (>=5.1.0,<6.0.0)", "gql (>=3.4.1,<4.0.0)", "html2text (>=2020.1.16,<2021.0.0)", "jq (>=1.4.1,<2.0.0)", "lxml (>=4.9.2,<5.0.0)", "pandas (>=2.0.1,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "psychicapi (>=0.2,<0.3)", "pymupdf (>=1.22.3,<2.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pypdfium2 (>=4.10.0,<5.0.0)", "requests-toolbelt (>=1.0.0,<2.0.0)", "telethon (>=1.28.5,<2.0.0)", "tqdm (>=4.48.0)", "zep-python (>=0.25,<0.26)"]
+hnswlib = ["docarray (>=0.31.0,<0.32.0)", "hnswlib (>=0.7.0,<0.8.0)", "protobuf (==3.19.6)"]
+in-memory-store = ["docarray (>=0.31.0,<0.32.0)"]
 llms = ["anthropic (>=0.2.6,<0.3.0)", "cohere (>=3,<4)", "huggingface_hub (>=0,<1)", "manifest-ml (>=0.0.1,<0.0.2)", "nlpcloud (>=1,<2)", "openai (>=0,<1)", "torch (>=1,<3)", "transformers (>=4,<5)"]
-openai = ["openai (>=0,<1)"]
+openai = ["openai (>=0,<1)", "tiktoken (>=0.3.2,<0.4.0)"]
 qdrant = ["qdrant-client (>=1.1.2,<2.0.0)"]
+text-helpers = ["chardet (>=5.1.0,<6.0.0)"]
 
 [[package]]
 name = "loguru"
@@ -3293,4 +3296,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "77173d8d30e449a05d8a29ad13fec9ac120485543fad361216bd9a822e38f823"
+content-hash = "ae337d6d7d84827821fa95118893a390cef393f50fbd559de8bdb85248b96e67"

--- a/prisma/migrations/20230522210313_document_openapi/migration.sql
+++ b/prisma/migrations/20230522210313_document_openapi/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "DocumentType" ADD VALUE 'OPENAPI';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = env("DATABASE_MIGRATION_URL")
 }
 
 enum AgentType {
@@ -22,6 +22,7 @@ enum DocumentType {
   TXT
   PDF
   YOUTUBE
+  OPENAPI
 }
 
 model User {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.9"
 fastapi = {extras = ["all"], version = "^0.95.1"}
 uvicorn = {extras = ["standard"], version = "^0.22.0"}
 gunicorn = "^20.1.0"
-langchain = "^0.0.161"
+langchain = "^0.0.177"
 openai = "^0.27.6"
 requests = "2.29.0"
 python-dotenv = "^1.0.0"


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->
This PR adds support for Natural Language API Agents. 

Currently only supports sync requests as support for `async` hasn't been released yet. 

This functionality is highly experimental at this point. 

Fixes #54 

Depends on

## Test plan

<!-- Include the steps to test your PR -->

- Add a document containing an OpenAPI `yaml` url to an API without authentication.
- Attach the document to an `Agent`.
- Use the following input payload:
```
{
    "has_streaming": false,
    "input": {"input": "You question"}
}
