### PR TITLE
Add `Cohere` LLM

### DIFF
--- a/app/api/api_tokens.py
+++ b/app/api/api_tokens.py
@@ -11,13 +11,13 @@ router = APIRouter()
 @router.post(
     "/api-tokens", name="Create API token", description="Create a new API token"
 )
-async def create_api_token(body: ApiToken, token=Depends(JWTBearer())):
+def create_api_token(body: ApiToken, token=Depends(JWTBearer())):
     """Create api token endpoint"""
     decoded = decodeJWT(token)
     token = generate_api_token()
 
     try:
-        agent = await prisma.apitoken.create(
+        agent = prisma.apitoken.create(
             {
                 "description": body.description,
                 "token": token,
@@ -36,10 +36,10 @@ async def create_api_token(body: ApiToken, token=Depends(JWTBearer())):
 
 
 @router.get("/api-tokens", name="List API tokens", description="List all API tokens")
-async def read_api_tokens(token=Depends(JWTBearer())):
+def read_api_tokens(token=Depends(JWTBearer())):
     """List api tokens endpoint"""
     decoded = decodeJWT(token)
-    api_tokens = await prisma.apitoken.find_many(
+    api_tokens = prisma.apitoken.find_many(
         where={"userId": decoded["userId"]}, include={"user": True}
     )
 
@@ -57,9 +57,9 @@ async def read_api_tokens(token=Depends(JWTBearer())):
     name="Get API token",
     description="Get a specific API token",
 )
-async def read_api_token(tokenId: str, token=Depends(JWTBearer())):
+def read_api_token(tokenId: str, token=Depends(JWTBearer())):
     """Get an api token endpoint"""
-    api_token = await prisma.apitoken.find_unique(
+    api_token = prisma.apitoken.find_unique(
         where={"id": tokenId}, include={"user": True}
     )
 
@@ -77,10 +77,10 @@ async def read_api_token(tokenId: str, token=Depends(JWTBearer())):
     name="Delete API token",
     description="Delete a specific API token",
 )
-async def delete_api_token(tokenId: str, token=Depends(JWTBearer())):
+def delete_api_token(tokenId: str, token=Depends(JWTBearer())):
     """Deleta api token endpoint"""
     try:
-        await prisma.apitoken.delete(where={"id": tokenId})
+        prisma.apitoken.delete(where={"id": tokenId})
 
         return {"success": True, "data": None}
     except Exception as e:

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -14,8 +14,8 @@ router = APIRouter()
 
 
 @router.post("/auth/sign-in")
-async def sign_in(signIn: SignIn):
-    user = await prisma.user.find_first(
+def sign_in(signIn: SignIn):
+    user = prisma.user.find_first(
         where={
             "email": signIn.email,
         },
@@ -35,18 +35,16 @@ async def sign_in(signIn: SignIn):
 
 
 @router.post("/auth/sign-up")
-async def sign_up(body: SignUp):
+def sign_up(body: SignUp):
     encryptPassword(body.password)
-    user = await prisma.user.create(
+    user = prisma.user.create(
         {
             "email": body.email,
             "password": encryptPassword(body.password),
             "name": body.name,
         }
     )
-    await prisma.profile.create(
-        {"userId": user.id, "metadata": json.dumps(body.metadata)}
-    )
+    prisma.profile.create({"userId": user.id, "metadata": json.dumps(body.metadata)})
 
     if user:
         return {"success": True, "data": user}

--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -9,7 +9,7 @@ router = APIRouter()
 
 
 @router.post("/documents", name="Create document", description="Create a new document")
-async def create_document(body: Document, token=Depends(JWTBearer())):
+def create_document(body: Document, token=Depends(JWTBearer())):
     """Create document endpoint"""
 
     try:
@@ -17,7 +17,7 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
         document_type = body.type
         document_url = body.url
         document_name = body.name
-        document = await prisma.document.create(
+        document = prisma.document.create(
             {
                 "type": document_type,
                 "url": document_url,
@@ -26,7 +26,7 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
             }
         )
 
-        await upsert_document(
+        upsert_document(
             url=document_url,
             type=document_type,
             document_id=document.id,
@@ -42,10 +42,10 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
 
 
 @router.get("/documents", name="List documents", description="List all documents")
-async def read_documents(token=Depends(JWTBearer())):
+def read_documents(token=Depends(JWTBearer())):
     """List documents endpoint"""
     decoded = decodeJWT(token)
-    documents = await prisma.document.find_many(
+    documents = prisma.document.find_many(
         where={"userId": decoded["userId"]}, include={"user": True}
     )
 
@@ -63,9 +63,9 @@ async def read_documents(token=Depends(JWTBearer())):
     name="Get document",
     description="Get a specific document",
 )
-async def read_document(documentId: str, token=Depends(JWTBearer())):
+def read_document(documentId: str, token=Depends(JWTBearer())):
     """Get a single document"""
-    document = await prisma.document.find_unique(
+    document = prisma.document.find_unique(
         where={"id": documentId}, include={"user": True}
     )
 
@@ -83,10 +83,10 @@ async def read_document(documentId: str, token=Depends(JWTBearer())):
     name="Delete document",
     description="Delete a specific document",
 )
-async def delete_document(documentId: str, token=Depends(JWTBearer())):
+def delete_document(documentId: str, token=Depends(JWTBearer())):
     """Delete a document"""
     try:
-        await prisma.document.delete(where={"id": documentId})
+        prisma.document.delete(where={"id": documentId})
 
         return {"success": True, "data": None}
     except Exception as e:

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -7,14 +7,12 @@ router = APIRouter()
 
 
 @router.get("/users/me")
-async def read_user_me(token=Depends(JWTBearer())):
+def read_user_me(token=Depends(JWTBearer())):
     decoded = decodeJWT(token)
 
     if "userId" in decoded:
         userId = decoded["userId"]
-        user = await prisma.user.find_unique(
-            where={"id": userId}, include={"profile": True}
-        )
+        user = prisma.user.find_unique(where={"id": userId}, include={"profile": True})
 
         return {"success": True, "data": user}
 
@@ -25,10 +23,8 @@ async def read_user_me(token=Depends(JWTBearer())):
 
 
 @router.get("/users/{userId}")
-async def read_user(userId: str):
-    user = await prisma.user.find_unique(
-        where={"id": userId}, include={"profile": True}
-    )
+def read_user(userId: str):
+    user = prisma.user.find_unique(where={"id": userId}, include={"profile": True})
 
     if user:
         return {"success": True, "data": user}

--- a/app/lib/agents.py
+++ b/app/lib/agents.py
@@ -9,7 +9,7 @@ from langchain.chains.conversational_retrieval.prompts import (
 from langchain.chains.question_answering import load_qa_chain
 from langchain.chat_models import ChatAnthropic, ChatOpenAI
 from langchain.embeddings.openai import OpenAIEmbeddings
-from langchain.llms import OpenAI
+from langchain.llms import OpenAI, Cohere
 from langchain.memory import ChatMessageHistory, ConversationBufferMemory
 from langchain.vectorstores.pinecone import Pinecone
 
@@ -38,13 +38,14 @@ class Agent:
         self.on_llm_end = on_llm_end
         self.on_chain_end = on_chain_end
 
-    async def _get_api_key(self) -> str:
+    def _get_api_key(self) -> str:
         if self.llm["provider"] == "openai-chat" or self.llm["provider"] == "openai":
             return (
                 self.llm["api_key"]
                 if "api_key" in self.llm
                 else config("OPENAI_API_KEY")
             )
+
         if self.llm["provider"] == "anthropic":
             return (
                 self.llm["api_key"]
@@ -52,12 +53,18 @@ class Agent:
                 else config("ANTHROPIC_API_KEY")
             )
 
-    async def _get_llm(self) -> Any:
+        if self.llm["provider"] == "cohere":
+            return (
+                self.llm["api_key"]
+                if "api_key" in self.llm
+                else config("COHERE_API_KEY")
+            )
+
+    def _get_llm(self) -> Any:
         if self.llm["provider"] == "openai-chat":
-            print(await self._get_api_key())
             return (
                 ChatOpenAI(
-                    openai_api_key=await self._get_api_key(),
+                    openai_api_key=self._get_api_key(),
                     model_name=self.llm["model"],
                     streaming=self.has_streaming,
                     callbacks=[
@@ -74,25 +81,28 @@ class Agent:
 
         if self.llm["provider"] == "openai":
             return OpenAI(
-                model_name=self.llm["model"], openai_api_key=await self._get_api_key()
+                model_name=self.llm["model"], openai_api_key=self._get_api_key()
             )
 
         if self.llm["provider"] == "anthropic":
             return (
                 ChatAnthropic(
                     streaming=self.has_streaming,
-                    anthropic_api_key=await self._get_api_key(),
+                    anthropic_api_key=self._get_api_key(),
                 )
                 if self.has_streaming
-                else ChatAnthropic(anthropic_api_key=await self._get_api_key())
+                else ChatAnthropic(anthropic_api_key=self._get_api_key())
             )
 
-        # Use ChatOpenAI as default llm in agents
-        return ChatOpenAI(temperature=0, openai_api_key=await self._get_api_key())
+        if self.llm["provider"] == "cohere":
+            return Cohere(cohere_api_key=self._get_api_key())
 
-    async def _get_memory(self) -> Any:
+        # Use ChatOpenAI as default llm in agents
+        return ChatOpenAI(temperature=0, openai_api_key=self._get_api_key())
+
+    def _get_memory(self) -> Any:
         if self.has_memory:
-            memories = await prisma.agentmemory.find_many(
+            memories = prisma.agentmemory.find_many(
                 where={"agentId": self.id},
                 order={"createdAt": "desc"},
                 take=5,
@@ -112,7 +122,7 @@ class Agent:
 
         return None
 
-    async def _get_document(self) -> Any:
+    def _get_document(self) -> Any:
         if self.document:
             embeddings = OpenAIEmbeddings()
             docsearch = Pinecone.from_existing_index(
@@ -123,10 +133,10 @@ class Agent:
 
         return None
 
-    async def get_agent(self) -> Any:
-        llm = await self._get_llm()
-        memory = await self._get_memory()
-        document = await self._get_document()
+    def get_agent(self) -> Any:
+        llm = self._get_llm()
+        memory = self._get_memory()
+        document = self._get_document()
         if document:
             question_generator = LLMChain(
                 llm=OpenAI(temperature=0), prompt=CONDENSE_QUESTION_PROMPT

--- a/app/lib/agents.py
+++ b/app/lib/agents.py
@@ -9,7 +9,7 @@ from langchain.chains.conversational_retrieval.prompts import (
 from langchain.chains.question_answering import load_qa_chain
 from langchain.chat_models import ChatAnthropic, ChatOpenAI
 from langchain.embeddings.openai import OpenAIEmbeddings
-from langchain.llms import OpenAI, Cohere
+from langchain.llms import Cohere, OpenAI
 from langchain.memory import ChatMessageHistory, ConversationBufferMemory
 from langchain.vectorstores.pinecone import Pinecone
 

--- a/app/lib/auth/api.py
+++ b/app/lib/auth/api.py
@@ -9,7 +9,7 @@ api_key_header = APIKeyHeader(name="X_SUPERAGENT_API_KEY", auto_error=False)
 
 async def get_api_key(api_key_header: str = Security(api_key_header)):
     try:
-        await prisma.apitoken.find_first(where={"token": api_key_header})
+        prisma.apitoken.find_first(where={"token": api_key_header})
 
         return api_key_header
 

--- a/app/lib/callbacks.py
+++ b/app/lib/callbacks.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, List, Optional, Union
 
-from langchain.callbacks.base import AsyncCallbackHandler
+from langchain.callbacks.base import BaseCallbackHandler
 from langchain.schema import AgentAction, AgentFinish, LLMResult
 
 
-class StreamingCallbackHandler(AsyncCallbackHandler):
+class StreamingCallbackHandler(BaseCallbackHandler):
     """Callback handler for streaming LLM responses."""
 
     def __init__(self, on_llm_new_token_, on_llm_end_, on_chain_end_) -> None:
@@ -18,13 +18,13 @@ class StreamingCallbackHandler(AsyncCallbackHandler):
         """Print out the prompts."""
         pass
 
-    async def on_llm_new_token(self, token: str, *args, **kwargs: Any) -> None:
+    def on_llm_new_token(self, token: str, *args, **kwargs: Any) -> None:
         """Run on new LLM token. Only available when streaming is enabled."""
-        await self.on_llm_new_token_(token)
+        self.on_llm_new_token_(token)
 
-    async def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
         """Do nothing."""
-        await self.on_llm_end_()
+        self.on_llm_end_()
 
     def on_llm_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
@@ -38,10 +38,9 @@ class StreamingCallbackHandler(AsyncCallbackHandler):
         """Print out that we are entering a chain."""
         pass
 
-    async def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
+    def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
         """Print out that we finished a chain."""
-        print(outputs, kwargs)
-        await self.on_chain_end_(outputs)
+        self.on_chain_end_(outputs)
 
     def on_chain_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any

--- a/app/lib/documents.py
+++ b/app/lib/documents.py
@@ -12,7 +12,7 @@ pinecone.init(
 )
 
 
-async def upsert_document(url: str, type: str, document_id: str) -> None:
+def upsert_document(url: str, type: str, document_id: str) -> None:
     """Upserts documents to Pinecone index"""
     pinecone.Index("superagent")
 

--- a/app/lib/prompts.py
+++ b/app/lib/prompts.py
@@ -1,9 +1,7 @@
 # flake8: noqa
 from langchain.prompts.prompt import PromptTemplate
 
-default_chat_template = """Assistant is a large language model trained by OpenAI.
-
-Assistant is designed to be able to assist with a wide range of tasks, from answering 
+default_chat_template = """Assistant is designed to be able to assist with a wide range of tasks, from answering 
 simple questions to providing in-depth explanations and discussions on a wide range of 
 topics.
 

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from app.routers import router
 app = FastAPI(
     title="Superagent",
     description="Bring your agents to production",
-    version="0.0.1",
+    version="0.0.7",
 )
 
 app.add_middleware(
@@ -20,13 +20,13 @@ app.add_middleware(
 
 
 @app.on_event("startup")
-async def startup():
-    await prisma.connect()
+def startup():
+    prisma.connect()
 
 
 @app.on_event("shutdown")
-async def shutdown():
-    await prisma.disconnect()
+def shutdown():
+    prisma.disconnect()
 
 
 app.include_router(router)

--- a/poetry.lock
+++ b/poetry.lock
@@ -494,6 +494,23 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "cohere"
+version = "4.5.1"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "cohere-4.5.1-py3-none-any.whl", hash = "sha256:46e777d5b76c69f93c2f589b574786599c9a8f13c1bbc9a969e68c194ba7da29"},
+    {file = "cohere-4.5.1.tar.gz", hash = "sha256:fbfa1e6696320ab41abdad2512de6e2e549ceb95da042c88fc6fe5c00c5f0530"},
+]
+
+[package.dependencies]
+aiohttp = ">=3.0,<4.0"
+backoff = ">=2.0,<3.0"
+requests = ">=2.0,<3.0"
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -3293,4 +3310,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "77173d8d30e449a05d8a29ad13fec9ac120485543fad361216bd9a822e38f823"
+content-hash = "76a209cf169e7e4fcdb2ebe66463b2d39b71d093c47e0e463c90d61e36b8681e"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider  = "prisma-client-py"
-  interface = "asyncio"
+  interface = "sync"
 }
 
 datasource db {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ flake8 = "^6.0.0"
 pinecone-client = "^2.2.1"
 tiktoken = "^0.4.0"
 pypdf = "^3.8.1"
+cohere = "^4.5.1"
 
 
 [build-system]


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

This PR adds the `Cohere` LLM. 

It also removes `async` support since most of the LangChain utilities do not support `async` calls. 

Fixes #50 

Depends on

## Test plan

<!-- Include the steps to test your PR -->

1. Create an agent with the following payload:
```
{
    "name": "Cohere agent",
    "type": "REACT",
    "llm": {"provider": "cohere", "model": "command"},
    "has_memory": false
}
```
2. Run the predict endpoint on the new Agent (does not support streaming).
