### PR TITLE
Add support for creating, listing and destroying prompts

### DIFF
--- a/app/api/prompts.py
+++ b/app/api/prompts.py
@@ -1,0 +1,62 @@
+import json
+
+from fastapi import APIRouter, Depends
+
+from app.lib.auth.prisma import JWTBearer, decodeJWT
+from app.lib.models.prompt import Prompt
+from app.lib.prisma import prisma
+
+router = APIRouter()
+
+
+@router.post("/prompts", name="Create a prompt", description="Create a new prompt")
+async def create_prompt(body: Prompt, token=Depends(JWTBearer())):
+    """Create prompt endpoint"""
+    decoded = decodeJWT(token)
+
+    prompt = prisma.prompts.create(
+        {
+            "name": body.name,
+            "input_variables": json.dumps(body.input_variables),
+            "template": body.template,
+            "userId": decoded["userId"],
+        },
+        include={"user": True},
+    )
+
+    return {"success": True, "data": prompt}
+
+
+@router.get("/prompts", name="List prompts", description="List all prompts")
+async def read_prompts(token=Depends(JWTBearer())):
+    """List prompts endpoint"""
+    decoded = decodeJWT(token)
+    prompts = prisma.prompts.find_many(
+        where={"userId": decoded["userId"]}, include={"user": True}
+    )
+
+    return {"success": True, "data": prompts}
+
+
+@router.get(
+    "/prompts/{promptId}",
+    name="Get prompt",
+    description="Get a specific prompt",
+)
+async def read_prompt(promptId: str, token=Depends(JWTBearer())):
+    """Get prompt endpoint"""
+    prompt = prisma.prompts.find_unique(where={"id": promptId}, include={"user": True})
+
+    return {"success": True, "data": prompt}
+
+
+@router.delete(
+    "/prompts/{promptId}",
+    name="Delete prompt",
+    description="Delete a specific prompt",
+)
+async def delete_prompt(promptId: str, token=Depends(JWTBearer())):
+    """Deleta prompt endpoint"""
+    prisma.prompts.delete(where={"id": promptId})
+
+    return {"success": True, "data": None}

--- a/app/lib/models/prompt.py
+++ b/app/lib/models/prompt.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class Prompt(BaseModel):
+    name: str
+    input_variables: list
+    template: str

--- a/app/routers.py
+++ b/app/routers.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api import agents, api_tokens, auth, documents, users
+from app.api import agents, api_tokens, auth, documents, users, prompts
 
 router = APIRouter()
 api_prefix = "/api/v1"
@@ -10,3 +10,4 @@ router.include_router(auth.router, tags=["Auth"], prefix=api_prefix)
 router.include_router(users.router, tags=["User"], prefix=api_prefix)
 router.include_router(api_tokens.router, tags=["Api token"], prefix=api_prefix)
 router.include_router(documents.router, tags=["Documents"], prefix=api_prefix)
+router.include_router(prompts.router, tags=["Prompts"], prefix=api_prefix)

--- a/prisma/migrations/20230522210313_document_openapi/migration.sql
+++ b/prisma/migrations/20230522210313_document_openapi/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "DocumentType" ADD VALUE 'OPENAPI';

--- a/prisma/migrations/20230524210134_prompts/migration.sql
+++ b/prisma/migrations/20230524210134_prompts/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - The values [OPENAPI] on the enum `DocumentType` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "DocumentType_new" AS ENUM ('TXT', 'PDF', 'YOUTUBE');
+ALTER TABLE "Document" ALTER COLUMN "type" DROP DEFAULT;
+ALTER TABLE "Document" ALTER COLUMN "type" TYPE "DocumentType_new" USING ("type"::text::"DocumentType_new");
+ALTER TYPE "DocumentType" RENAME TO "DocumentType_old";
+ALTER TYPE "DocumentType_new" RENAME TO "DocumentType";
+DROP TYPE "DocumentType_old";
+ALTER TABLE "Document" ALTER COLUMN "type" SET DEFAULT 'TXT';
+COMMIT;
+
+-- CreateTable
+CREATE TABLE "Prompts" (
+    "id" VARCHAR(255) NOT NULL,
+    "template" TEXT NOT NULL,
+    "input_variables" JSONB NOT NULL,
+    "userId" VARCHAR(255) NOT NULL,
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Prompts_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Prompts" ADD CONSTRAINT "Prompts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20230524210521_prompts_name/migration.sql
+++ b/prisma/migrations/20230524210521_prompts_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `name` to the `Prompts` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Prompts" ADD COLUMN     "name" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = env("DATABASE_MIGRATION_URL")
 }
 
 enum AgentType {
@@ -36,6 +36,7 @@ model User {
   Agent     Agent[]
   ApiToken  ApiToken[]
   Document  Document[]
+  Prompts   Prompts[]
 }
 
 model Profile {
@@ -90,4 +91,16 @@ model AgentMemory {
   createdAt DateTime?             @default(now())
   updatedAt DateTime?             @default(now())
   deletedAt DateTime?
+}
+
+model Prompts {
+  id              String    @id @default(cuid()) @db.VarChar(255)
+  name            String
+  template        String    @db.Text()
+  input_variables Json
+  userId          String    @db.VarChar(255)
+  user            User      @relation(fields: [userId], references: [id])
+  createdAt       DateTime? @default(now())
+  updatedAt       DateTime? @default(now())
+  deletedAt       DateTime?
 }


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

This PR adds an API for creating, listing and destroying prompts.

Fixes #17 


## Test plan

<!-- Include the steps to test your PR -->

1. POST /prompts
2. GET /prompts
3. GET /prompts/id
4. DEL /promtps/id
