### PR TITLE
Add psychic integration

### DIFF
--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -33,6 +33,7 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
             text_splitter=body.splitter,
             from_page=body.from_page,
             to_page=body.to_page,
+            user_id=decoded["userId"]
         )
 
     return {"success": True, "data": document}

--- a/app/lib/documents.py
+++ b/app/lib/documents.py
@@ -16,7 +16,7 @@ from app.lib.parsers import CustomPDFPlumberLoader
 from app.lib.splitters import TextSplitters
 from app.lib.vectorstores.base import VectorStoreBase
 
-valid_ingestion_types = ["TXT", "PDF", "URL", "YOUTUBE", "MARKDOWN", "API"]
+valid_ingestion_types = ["TXT", "PDF", "URL", "YOUTUBE", "MARKDOWN", "PSYCHIC"]
 
 
 def upsert_document(
@@ -111,7 +111,7 @@ def upsert_document(
             docs, embeddings, index_name="superagent", namespace=document_id
         )
     
-    if type == "API":
+    if type == "PSYCHIC":
         loader = PsychicLoader(api_key=config("PSYCHIC_API_KEY"), account_id=user_id)
         documents = loader.load()
         newDocuments = [

--- a/ui/app/documents/client-page.js
+++ b/ui/app/documents/client-page.js
@@ -215,6 +215,7 @@ export default function DocumentsClientPage({ data, session }) {
                     <option value="URL">URL</option>
                     <option value="YOUTUBE">Youtube</option>
                     <option value="MARKDOWN">Markdown</option>
+                    <option value="API">API</option>
                   </Select>
                   {errors?.type && (
                     <FormErrorMessage>Invalid type</FormErrorMessage>

--- a/ui/app/documents/client-page.js
+++ b/ui/app/documents/client-page.js
@@ -221,7 +221,7 @@ export default function DocumentsClientPage({ data, session }) {
                     <option value="URL">URL</option>
                     <option value="YOUTUBE">Youtube</option>
                     <option value="MARKDOWN">Markdown</option>
-                    <option value="API">API</option>
+                    <option value="PSYCHIC">Psychic API</option>
                   </Select>
                   {errors?.type && (
                     <FormErrorMessage>Invalid type</FormErrorMessage>
@@ -259,10 +259,10 @@ export default function DocumentsClientPage({ data, session }) {
                     </Stack>
                   </FormControl>
                 )}
-                {documentType === "API" && (
+                {documentType === "PSYCHIC" && (
                   <FormControl>
                     <Stack marginTop={4}>
-                    <Button type="submit" disabled={!isPsychicReady} onClick={onConnectAPI} isLoading={isPsychicLoading}>
+                    <Button type="submit" disabled={!isPsychicReady} onClick={onConnectPsychic} isLoading={isPsychicLoading}>
                       Connect
                     </Button>
                     </Stack>

--- a/ui/app/documents/client-page.js
+++ b/ui/app/documents/client-page.js
@@ -37,6 +37,7 @@ import { TbPlus, TbCopy, TbTrash } from "react-icons/tb";
 import { useForm } from "react-hook-form";
 import API from "@/lib/api";
 import { analytics } from "@/lib/analytics";
+import { usePsychicLink } from "@psychic-api/link";
 
 function DocumentRow({ id, name, type, url, onDelete }) {
   const toast = useToast();
@@ -101,6 +102,7 @@ export default function DocumentsClientPage({ data, session }) {
   } = useForm();
 
   const documentType = watch("type");
+  const { openPsychic, isPsychicReady, isPsychicLoading} = usePsychicLink(publicKey, () => {});
 
   const onSubmit = async (values) => {
     const { type, name, url, auth_type, auth_key, auth_value } = values;
@@ -128,6 +130,10 @@ export default function DocumentsClientPage({ data, session }) {
 
     analytics.track("Deleted Document", { id });
     router.refresh();
+  };
+
+  const onConnectAPI = async () => {
+    openPsychic(session.user.user.id);
   };
 
   return (
@@ -250,6 +256,15 @@ export default function DocumentsClientPage({ data, session }) {
                           authentication you need to use the fields above.
                         </FormHelperText>
                       </Box>
+                    </Stack>
+                  </FormControl>
+                )}
+                {documentType === "API" && (
+                  <FormControl>
+                    <Stack marginTop={4}>
+                    <Button type="submit" disabled={!isPsychicReady} onClick={onConnectAPI} isLoading={isPsychicLoading}>
+                      Connect
+                    </Button>
                     </Stack>
                   </FormControl>
                 )}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
         "@microsoft/fetch-event-source": "^2.0.1",
+        "@psychic-api/link": "^1.1.1",
         "@uiw/codemirror-theme-github": "^4.21.3",
         "@uiw/codemirror-theme-xcode": "^4.19.16",
         "@uiw/react-codemirror": "^4.19.16",
@@ -2322,6 +2323,17 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@psychic-api/link": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@psychic-api/link/-/link-1.1.1.tgz",
+      "integrity": "sha512-RceCc1/+vOgBJSkUd49sS+tbnr9s9XpfEl4gCYFhvM8Eq5ZgzDxC/VrFhlPIdv+aXw8WLb/TYTptwMDBjqLyiA==",
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "@types/react-dom": ">=17.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz",
@@ -2426,6 +2438,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
+      "integrity": "sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==",
+      "peer": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/scheduler": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@microsoft/fetch-event-source": "^2.0.1",
+    "@psychic-api/link": "^1.1.1",
     "@uiw/codemirror-theme-github": "^4.21.3",
     "@uiw/codemirror-theme-xcode": "^4.19.16",
     "@uiw/react-codemirror": "^4.19.16",


### PR DESCRIPTION
## Summary

Add psychic as a source of documents for superagent's backend.

Fixes
- N/a

Depends on
- no new dependencies

## Test plan
- will test locally before merging in

-

## Screenshots
![CleanShot 2023-05-31 at 20 17 35@2x](https://github.com/homanp/superagent/assets/14931371/642df344-65df-4e6f-985c-3f12d8205009)


## Types of changes

## Checklist

- [x] My code follows the code style of this project and passes {`style_guide_run_command`}.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate [Unit Test coverage]({TestCoverage}).
