### PR TITLE
Add a `URL` document type for ingesting HTML into pinecone

### DIFF
--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -3,7 +3,7 @@ import json
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.lib.auth.prisma import JWTBearer, decodeJWT
-from app.lib.documents import upsert_document
+from app.lib.documents import upsert_document, valid_ingestion_types
 from app.lib.models.document import Document
 from app.lib.prisma import prisma
 
@@ -26,7 +26,7 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
             }
         )
 
-        if body.type == "TXT" or body.type == "PDF":
+        if body.type in valid_ingestion_types:
             upsert_document(
                 url=body.url,
                 type=body.type,

--- a/poetry.lock
+++ b/poetry.lock
@@ -255,6 +255,25 @@ tests = ["pytest (>=3.2.1,!=3.3.0)"]
 typecheck = ["mypy"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.12.2"
+description = "Screen-scraping library"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+files = [
+    {file = "beautifulsoup4-4.12.2-py3-none-any.whl", hash = "sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"},
+    {file = "beautifulsoup4-4.12.2.tar.gz", hash = "sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "23.3.0"
 description = "The uncompromising code formatter."
@@ -303,6 +322,20 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "bs4"
+version = "0.0.1"
+description = "Dummy package for Beautiful Soup"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "bs4-0.0.1.tar.gz", hash = "sha256:36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a"},
+]
+
+[package.dependencies]
+beautifulsoup4 = "*"
 
 [[package]]
 name = "certifi"
@@ -2637,6 +2670,18 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.4.1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "soupsieve-2.4.1-py3-none-any.whl", hash = "sha256:1c1bfee6819544a3447586c889157365a27e10d88cde3ad3da0cf0ddf646feb8"},
+    {file = "soupsieve-2.4.1.tar.gz", hash = "sha256:89d12b2d5dfcd2c9e8c22326da9d9aa9cb3dfab0a83a024f05704076ee8d35ea"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.15"
 description = "Database Abstraction Library"
@@ -3475,4 +3520,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "03a8bb71d5e52d4e15097f0a01f452f3f6c7649aae19a62afa15a8dbde281041"
+content-hash = "bc4d24474bdfa8e66dd0154dbe8198dba50c413cfe324a8e320718f45570bc30"

--- a/prisma/migrations/20230612120653_tool_type_scraper/migration.sql
+++ b/prisma/migrations/20230612120653_tool_type_scraper/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ToolType" ADD VALUE 'SCRAPER';

--- a/prisma/migrations/20230612124651_remove_tool_scraper/migration.sql
+++ b/prisma/migrations/20230612124651_remove_tool_scraper/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The values [SCRAPER] on the enum `ToolType` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "ToolType_new" AS ENUM ('BROWSER', 'SEARCH', 'WOLFRAM_ALPHA');
+ALTER TABLE "Tool" ALTER COLUMN "type" TYPE "ToolType_new" USING ("type"::text::"ToolType_new");
+ALTER TYPE "ToolType" RENAME TO "ToolType_old";
+ALTER TYPE "ToolType_new" RENAME TO "ToolType";
+DROP TYPE "ToolType_old";
+COMMIT;

--- a/prisma/migrations/20230612124840_document_type_url/migration.sql
+++ b/prisma/migrations/20230612124840_document_type_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "DocumentType" ADD VALUE 'URL';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ enum DocumentType {
   PDF
   YOUTUBE
   OPENAPI
+  URL
 }
 
 enum ToolType {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ cohere = "^4.5.1"
 wolframalpha = "^5.0.0"
 langchain = "^0.0.195"
 huggingface-hub = "^0.15.1"
+bs4 = "^0.0.1"
 
 
 [build-system]


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->
This PR adds a `URL` document type for ingesting HTML into pinecone
Specific content can be retrieved using the QA Retrieval Agent just like any other document. 

Future releases will include ingestion for multiple URLs and whole `sitemaps`.

Fixes #92 

## Test plan

<!-- Include the steps to test your PR -->

- Create a document of type `URL`
- Attach document to `Agent`
- Run `Agent`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `make format`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
