### PR TITLE
add custom pdf parser

### DIFF
--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -31,6 +31,8 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
                 url=body.url,
                 type=body.type,
                 document_id=document.id,
+                from_page=body.from_page,
+                to_page=body.to_page
             )
 
         return {"success": True, "data": document}

--- a/app/lib/documents.py
+++ b/app/lib/documents.py
@@ -1,10 +1,12 @@
 import pinecone
 import requests
 from decouple import config
-from langchain.document_loaders import PyPDFLoader, TextLoader, WebBaseLoader
+from langchain.document_loaders import TextLoader, WebBaseLoader
 from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.vectorstores.pinecone import Pinecone
+
+from app.lib.parsers import CustomPDFPlumberLoader
 
 pinecone.init(
     api_key=config("PINECONE_API_KEY"),  # find at app.pinecone.io
@@ -14,7 +16,7 @@ pinecone.init(
 valid_ingestion_types = ["TXT", "PDF", "URL"]
 
 
-def upsert_document(url: str, type: str, document_id: str) -> None:
+def upsert_document(url: str, type: str, document_id: str, from_page: int, to_page: int) -> None:
     """Upserts documents to Pinecone index"""
     pinecone.Index("superagent")
 
@@ -33,7 +35,7 @@ def upsert_document(url: str, type: str, document_id: str) -> None:
 
     if type == "PDF":
         file_response = requests.get(url)
-        loader = PyPDFLoader(file_path=url)
+        loader = CustomPDFPlumberLoader(file_path=url, from_page=from_page, to_page=to_page)
         documents = loader.load()
         text_splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=0)
         docs = text_splitter.split_documents(documents)

--- a/app/lib/models/document.py
+++ b/app/lib/models/document.py
@@ -6,3 +6,5 @@ class Document(BaseModel):
     url: str
     name: str
     authorization: dict = None
+    from_page: int = 1,
+    to_page: int = None

--- a/app/lib/parsers.py
+++ b/app/lib/parsers.py
@@ -1,7 +1,11 @@
 import re
-from typing import Union
+from typing import Any, Iterator, List, Mapping, Optional, Union
 
 from langchain.agents import AgentOutputParser
+from langchain.docstore.document import Document
+from langchain.document_loaders.base import BaseBlobParser
+from langchain.document_loaders.blob_loaders import Blob
+from langchain.document_loaders.pdf import BasePDFLoader
 from langchain.schema import AgentAction, AgentFinish
 
 
@@ -23,3 +27,97 @@ class CustomOutputParser(AgentOutputParser):
         return AgentAction(
             tool=action, tool_input=action_input.strip(" ").strip('"'), log=llm_output
         )
+
+
+class CustomPDFPlumberLoader(BasePDFLoader):
+    """Loader that uses pdfplumber to load PDF files."""
+
+    def __init__(
+        self,
+        file_path: str, 
+        from_page: int = 1, 
+        to_page: Optional[int] = None,
+        text_kwargs: Optional[Mapping[str, Any]] = None
+    ) -> None:
+        """Initialize with file path."""
+        try:
+            import pdfplumber  # noqa:F401
+        except ImportError:
+            raise ImportError(
+                "pdfplumber package not found, please install it with "
+                "`pip install pdfplumber`"
+            )
+
+        super().__init__(file_path)
+        self.text_kwargs = text_kwargs or {}
+        self.from_page = from_page
+        self.to_page = to_page or None
+
+    def load(self) -> List[Document]:
+        """Load file."""
+
+        parser = CustomPDFPlumberParser(
+            text_kwargs=self.text_kwargs, 
+            from_page=self.from_page,
+            to_page=self.to_page
+        )
+        blob = Blob.from_path(self.file_path)
+        return parser.parse(blob)
+
+
+
+class CustomPDFPlumberParser(BaseBlobParser):
+    """Custom PDF Parser which optionally takes in account the min page number to process"""
+
+    def __init__(
+            self, 
+            text_kwargs: Optional[Mapping[str, Any]] = None, 
+            from_page: int = 1,
+            to_page: Optional[int] = None
+        ) -> None:
+        """Initialize the parser.
+
+        Args:
+            text_kwargs: Keyword arguments to pass to ``pdfplumber.Page.extract_text()``
+        """
+        self.text_kwargs = text_kwargs or {}
+        self.from_page = from_page
+        self.to_page = to_page
+
+    def lazy_parse(self, blob: Blob) -> Iterator[Document]:
+        """Lazily parse the blob."""
+        import pdfplumber
+
+        with blob.as_bytes_io() as file_path:
+            if self.to_page is None:
+                # by default, starts from 1 and processes the whole document
+                doc = pdfplumber.open(file_path)
+            else:
+                if self.to_page > 0:
+                    """Parse till the maximum page number provided"""
+                    doc = pdfplumber.open(
+                        file_path, 
+                        pages=list(range(self.from_page, self.to_page))
+                    )
+                else:
+                    raise ValueError("Value of to_page should be greater than equal to 1.")
+
+            yield from [
+                Document(
+                    page_content=page.extract_text(**self.text_kwargs),
+                    metadata=dict(
+                        {
+                            "source": blob.source,
+                            "file_path": blob.source,
+                            "page": page.page_number,
+                            "total_pages": len(doc.pages),
+                        },
+                        **{
+                            k: doc.metadata[k]
+                            for k in doc.metadata
+                            if type(doc.metadata[k]) in [str, int]
+                        },
+                    ),
+                )
+                for page in doc.pages
+            ]


### PR DESCRIPTION
## Summary

Added custom PDF parser which takes in account `from_page` and `to_page` for more flexibility.

Fixes #104 

Depends on: Make sure to install `pip install pdfplumber` before testing out.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
