### PR TITLE
Remove `bearer token` security from OpenAPI

### DIFF
--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -1112,9 +1112,6 @@ components:
           title: Error Type
           type: string
   securitySchemes:
-    JWTBearer:
-      type: http
-      scheme: bearer
     APIKeyHeader:
       type: apiKey
       in: header


### PR DESCRIPTION
The SDKs should use APIKeyHeader based auth, so removing the JWTBearer security scheme.