### PR TITLE
🌿 Add TypeScript SDK generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Fern
-        run:  npm install -g fern-api
+        run: npm install -g fern-api
 
       - name: Check Fern API is valid
         run: fern check
@@ -33,4 +33,5 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: fern generate --group publish --log-level debug --version ${{ github.ref_name }}

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -20,6 +20,5 @@ groups:
           token: ${NPM_TOKEN}
         config:
           namespaceExport: SuperAgent
-          timeoutInSeconds: infinity
         github:
           repository: homanp/superagent-js

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -11,3 +11,15 @@ groups:
           repository: homanp/superagent-py
         config:
           client_class_name: Superagent
+
+      - name: fernapi/fern-typescript-node-sdk
+        version: 0.7.1
+        output:
+          location: npm
+          package-name: superagentai-js
+          token: ${NPM_TOKEN}
+        config:
+          namespaceExport: SuperAgent
+          timeoutInSeconds: infinity
+        github:
+          repository: homanp/superagent-js


### PR DESCRIPTION
Adds a new Fern TypeScript Node SDK generator and the `NPM_TOKEN` environment variable to the `fern-generate` job in the `ci` workflow.