### PR TITLE
Add docker-compose for easy local setup

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -16,7 +16,7 @@
 
    ``` bash
    # the example values are placeholders but they will work just fine locally.
-   `cp .docker/docker.example.env .docker/docker.env`
+   cp .docker/docker.example.env .docker/docker.env
    ```
 
 3. In order to connect to the db running in docker, with the example values from `docker.env`, set the following in the root `.env`. Set the `DATABASE_URL` and `DATABASE_MIGRATION_URL` to the same value and comment out, or remove the `DATABASE_SHADOW_URL`

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -71,3 +71,21 @@ docker-compose --env-file docker.env -f docker-compose.pgdb.yml -f docker-compos
 docker-compose --env-file docker.env -f docker-compose.pgdb.yml -f docker-compose.ui.yml up --build -d
 
 ```
+
+## Viewing logs in the Docker containers
+
+Each container is named so you can easily view the logs using docker on the CMD line
+
+``` bash
+# UI logs
+docker logs superagent-ui -f
+
+# API logs
+docker logs superagent-api -f
+
+# DB logs
+docker logs superagent-pgdb -f
+
+## Adminer logs
+docker logs superagent-adminer -f
+```

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,0 +1,73 @@
+# Run Superagent locally with Docker and docker-compose
+
+## Setup environment variables first
+
+1. Create and fill in the API and UI environment variables. Check the `README` for both the API and the UI for details.
+
+   ``` bash
+   # create the api env file
+   cp .env.example .env
+
+   # create the ui env file
+   cp ui/.env.example ui/.env
+   ```
+
+2. Copy the `.docker/docker.example.env` into a `docker.env` file.
+
+   ``` bash
+   # the example values are placeholders but they will work just fine locally.
+   `cp .docker/docker.example.env .docker/docker.env`
+   ```
+
+3. In order to connect to the db running in docker, with the example values from `docker.env`, set the following in the root `.env`. Set the `DATABASE_URL` and `DATABASE_MIGRATION_URL` to the same value and comment out, or remove the `DATABASE_SHADOW_URL`
+
+    ``` bash
+    # .env
+    DATABASE_URL=postgresql://admin:password@localhost:5432/superagent
+    DATABASE_MIGRATION_URL=postgresql://admin:password@localhost:5432/superagent
+    # DATABASE_SHADOW_URL= # Mandatory for Neon DB
+    ```
+
+## Run Superagent with docker-compose
+
+After you have carefully set all the values in both the root `.env`, `ui/.env` and `.docker/docker.env` files, you can spin everything up in docker:
+
+### Run the UI. API and a Postgres DB together
+
+``` bash
+cd .docker
+docker-compose --env-file docker.env up --build -d
+
+# you can spin everything down with
+docker compose down
+
+# It's often best to combine these and run this everytime to avoid issues
+docker compose down && docker-compose --env-file docker.env up --build -d
+
+```
+
+### Run any single part individually or in combination with docker-compose.
+
+You can run just the bits you need in docker, meaning you can run the UI locally with npm, or the API with venv/conda locally to develop, while only running dependencies in docker for example.
+
+Or if you are developing only the UI for example, you could just run both the API and DB in docker, while running the UI with npm locally, any combination is fine.
+
+``` bash
+cd .docker
+
+# Run just the Postgress DB 
+docker-compose --env-file docker.env -f docker-compose.pgdb.yml up --build -d
+
+# Run just the UI
+docker-compose --env-file docker.env -f docker-compose.ui.yml up --build -d
+
+# Run just the API
+docker-compose --env-file docker.env -f docker-compose.api.yml up --build -d
+
+# Run the DB and the API together
+docker-compose --env-file docker.env -f docker-compose.pgdb.yml -f docker-compose.api.yml up --build -d
+
+# Run the DB and the UI together
+docker-compose --env-file docker.env -f docker-compose.pgdb.yml -f docker-compose.ui.yml up --build -d
+
+```

--- a/.docker/docker-compose.api.yml
+++ b/.docker/docker-compose.api.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  superagent-api:
+    container_name: superagent-api
+    network_mode: "host"
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    command: ["/bin/bash", "setup.docker.sh"]
+    environment:
+      - PORT=8080
+    env_file:
+      - ../.env

--- a/.docker/docker-compose.pgdb.yml
+++ b/.docker/docker-compose.pgdb.yml
@@ -1,0 +1,35 @@
+version: "3"
+
+services:
+  pgdb:
+    container_name: pgdb
+    network_mode: "host"
+    image: postgres:12
+    restart: unless-stopped
+    volumes:
+      - type: volume
+        source: pgdb-data
+        target: "/var/lib/postgresql/data"
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: ${DBUSER}
+      POSTGRES_PASSWORD: ${DBPASS}
+
+  pgadmin:
+    container_name: pgadmin
+    network_mode: "host"
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+      PGADMIN_LISTEN_ADDRESS: 0.0.0.0
+      PGADMIN_LISTEN_PORT: 5050
+    volumes:
+      - type: volume
+        source: pgadmin-data
+        target: /root/.pgadmin
+    restart: unless-stopped
+
+volumes:
+  pgdb-data:
+  pgadmin-data:

--- a/.docker/docker-compose.ui.yml
+++ b/.docker/docker-compose.ui.yml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  superagent-ui:
+    container_name: superagent-ui
+    network_mode: "host"
+    build:
+      context: ../ui
+      dockerfile: Dockerfile
+    env_file:
+      - ../ui/.env

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,61 @@
+version: "3"
+
+services:
+  superagent-ui:
+    container_name: superagent-ui
+    network_mode: "host"
+    build:
+      context: ../ui
+      dockerfile: Dockerfile
+    env_file:
+      - ../ui/.env
+    depends_on:
+      - superagent-api
+
+  superagent-api:
+    container_name: superagent-api
+    network_mode: "host"
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    command: ["/bin/bash", "setup.docker.sh"]
+    environment:
+      - PORT=8080
+    env_file:
+      - ../.env
+    depends_on:
+      - pgdb
+      - pgadmin
+
+  pgdb:
+    container_name: pgdb
+    network_mode: "host"
+    image: postgres:12
+    restart: unless-stopped
+    volumes:
+      - type: volume
+        source: pgdb-data
+        target: "/var/lib/postgresql/data"
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: ${DBUSER}
+      POSTGRES_PASSWORD: ${DBPASS}
+
+  pgadmin:
+    container_name: pgadmin
+    network_mode: "host"
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+      PGADMIN_LISTEN_ADDRESS: 0.0.0.0
+      PGADMIN_LISTEN_PORT: 5050
+    volumes:
+      - type: volume
+        source: pgadmin-data
+        target: /root/.pgadmin
+    restart: unless-stopped
+
+volumes:
+  pgdb-data:
+  pgadmin-data:

--- a/.docker/docker.env.example
+++ b/.docker/docker.env.example
@@ -1,0 +1,6 @@
+DBUSER=admin
+DBPASS=password
+DBNAME=superagent
+
+PGADMIN_DEFAULT_EMAIL=dev@superagent.sh
+PGADMIN_DEFAULT_PASSWORD=password

--- a/.docker/run.docker.sh
+++ b/.docker/run.docker.sh
@@ -1,0 +1,22 @@
+## To run everything in docker locally (UI, API, DB, etc.)
+
+docker-compose --env-file docker.env up --build -d
+
+## When developing just the UI locally, you can run the following:
+## This will only run the DB and API in docker
+## You can then run the UI locally with `npm run dev`
+
+# docker-compose --env-file docker.env -f docker-compose.deps.yml -f docker-compose.api.yml up --build -d
+
+## Or if you are only developing with the API, you can run the following:
+##This will only run the DB and UI in docker
+## you can then run the API locally with venv
+
+# docker-compose --env-file docker.env -f docker-compose.deps.yml -f docker-compose.ui.yml up --build -d
+
+## If you just want to run the DB in docker, so you can run API and UI locally
+
+# docker-compose --env-file docker.env -f docker-compose.deps.yml up --build -d
+
+## Any combimation of the above is possible, add one or more of the docker-compose files to the command
+# docker-compose --env-file docker.env -f docker-compose.ui.yml up --build -d

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,6 @@
 env/
 venv/
 ENV/
+
+# UI
+ui/

--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,12 @@ DATABASE_URL=
 DATABASE_MIGRATION_URL=
 DATABASE_SHADOW_URL= # Mandatory for Neon DB
 JWT_SECRET=
+
+## Pinecone Vector Store
 VECTORSTORE=pinecone
 PINECONE_API_KEY=
 PINECONE_ENVIRONMENT=
+
 SUPERAGENT_TRACING=False
 
 # Mandatory if you want to run Psychic

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# docker
+.docker/docker.env
+.docker/data/

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ To get started with Superagent, follow these steps:
 ## Deploy on Replit
 Superagent has first grade support for running on [Replit](https://replit.com). You can use the official public Repl to get started.
 
+## Run locally with docker and docker compose
+
+In the `.docker` folder there are multiple docker-compose files.
+
+The main `docker-compose.yml` file can be used to build and setup everything needed to run superagent at once. This is the quickest way to run superagent locally. It includes both the API and UI, as well as a Postgres DB with the Adminer tool to administer it.
+
+The other docker compose files can be used individually, or in combination to start up just the bits you need.
+
+All the docker-compose files start up resources using the `network_mode: "host"` option to simulate running on localhost, this avoids any issues with container networking and makes sure each one can communicate with the others, even if you start up different parts seperately.
+
+> follow the guide in `.docker/README.md` file to get started
+
 ## 🌎 Environment variables
 
 To run this project, you will need to add the following environment variables to your .env file

--- a/setup.docker.sh
+++ b/setup.docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Run Prisma migration
+prisma migrate dev
+
+# Start the application with auto-reload
+gunicorn --bind :$PORT --workers 2 --timeout 0  --worker-class uvicorn.workers.UvicornWorker  --threads 8 app.main:app

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,12 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.next
+.git
+next.config.js
+dist
+packages
+.env.local
+.env.prod.local

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,7 +1,8 @@
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="superagent"
-NEXT_PUBLIC_SUPERAGENT_API_URL="http://127.0.0.1:8000/api/v1"
-NEXT_PUBLIC_SHARABLE_KEY_SECRET="" # Needs to be exactly 16 characters
+NEXT_PUBLIC_SUPERAGENT_API_URL="http://127.0.0.1:8080/api/v1"
+# Shareable Key Needs to be exactly 16 characters, do not wrap value in quotes
+NEXT_PUBLIC_SHARABLE_KEY_SECRET=
 
 # Optional variables
 NEXT_PUBLIC_STRIPE_SECRET_KEY=""

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,43 @@
+# Build stage
+FROM node:18-alpine AS build
+
+# Install dependencies only when needed
+RUN apk add --no-cache libc6-compat
+
+# Set working directory
+WORKDIR /app
+
+# Copy and install the dependencies for the project
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy all other project files to working directory
+COPY . .
+
+# Run the next build process and generate the artifacts
+RUN npm run build
+
+# Runner stage
+FROM node:18-alpine AS runner
+
+# Set environment variables
+ENV NODE_ENV production
+
+# Set working directory
+WORKDIR /app
+
+# Copy the next files from the build stage
+COPY --from=build /app/.next ./.next
+
+# Copy the public folder from the build stage
+COPY --from=build /app/public ./public
+
+# Copy the package.json and package-lock.json files from the build stage
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/package-lock.json ./package-lock.json
+
+# Install production dependencies only
+RUN npm ci --only=production
+
+# Start the application
+CMD ["npm", "start"]

--- a/ui/app/agents/[agentId]/_components/nav.js
+++ b/ui/app/agents/[agentId]/_components/nav.js
@@ -59,12 +59,14 @@ export default function AgentNavbar({ agent, apiToken, hasApiTokenWarning }) {
   );
 
   const copyToClipboard = () => {
+    const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://app.superagent.sh';
+
     navigator.clipboard.writeText(
-      `https://app.superagent.sh/share?agentId=${agent.id}&token=${encrypt(
+      `${baseUrl}/share?agentId=${agent.id}&token=${encrypt(
         apiToken?.token
       )}`
     );
-
+    
     toast({
       description: "Share link copied!",
       position: "top",

--- a/ui/app/share/client-page.js
+++ b/ui/app/share/client-page.js
@@ -161,8 +161,10 @@ export default function ShareClientPage({ agent, token }) {
   };
 
   const handleCopyShareLink = () => {
+    const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://app.superagent.sh';
+    
     navigator.clipboard.writeText(
-      `https://app.superagent.sh/share?agentId=${agent.id}&token=${token}`
+      `${baseUrl}/share?agentId=${agent.id}&token=${token}`
     );
 
     toast({


### PR DESCRIPTION
## Summary

This PR provides several docker-compose files, and the supporting files needed to run them. These allow for easily running Superagent locally, by either running everything in docker with one command, or by picking and running any individual service, or a combination of services.

A main `docker-compose.yml` file is provided in order to run both the UI and API as well as a Postgres DB in Docker, with the Adminer tool for DB admin.

Separate docker-compose files are provided for the DB, the API and the UI. These can be run individually or in combination to suit the needs of the individual.

A note has been added to the main README.md, pointing to new documentation in the `.docker/README.md` file.

## Fixes
- Fix hardcoded URLs in `ui\app\agents\[agentId]\_components\nav.js` and `ui\app\share\client-page.js` to be able to test sharing locally.
- Minor change to `.env.example`: remove quotes around `NEXT_PUBLIC_SHARABLE_KEY_SECRET` and move comment to line above (so anyone leaving the comment in won't have it appear in the value)
- ignore `ui` folder in API `.dockerignore` to prevent the whole UI being copied into the API container.

## Test plan

Follow the guide in `.docker/README.md`
