### PR TITLE
Load the content directly without URL

### DIFF
--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 
@@ -17,10 +18,28 @@ router = APIRouter()
 async def create_document(body: Document, token=Depends(JWTBearer())):
     """Create document endpoint"""
     try:
+        # Check if a document with the same content hash already exists
+        if body.content is not None:
+            content_hash = hashlib.sha256(body.content.encode()).hexdigest()
+        else:
+            content_hash = None
+        existing_document = prisma.document.find_first(
+            where={"contentHash": content_hash})
+
+        if existing_document:
+            return {
+                "success": False,
+                "message": "Document with the same content already exists",
+                "data": existing_document,
+            }
+
         document = prisma.document.create(
             {
                 "type": body.type,
                 "url": body.url,
+
+                "content": body.content,
+                "contentHash": content_hash,
                 "userId": token["userId"],
                 "name": body.name,
                 "splitter": json.dumps(body.splitter),
@@ -32,6 +51,7 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
         if body.type in valid_ingestion_types:
             upsert_document(
                 url=body.url,
+                content=body.content,
                 type=body.type,
                 document_id=document.id,
                 authorization=body.authorization,

--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -24,7 +24,8 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
         else:
             content_hash = None
         existing_document = prisma.document.find_first(
-            where={"contentHash": content_hash})
+            where={"contentHash": content_hash}
+        )
 
         if existing_document:
             return {
@@ -37,7 +38,6 @@ async def create_document(body: Document, token=Depends(JWTBearer())):
             {
                 "type": body.type,
                 "url": body.url,
-
                 "content": body.content,
                 "contentHash": content_hash,
                 "userId": token["userId"],

--- a/app/lib/documents.py
+++ b/app/lib/documents.py
@@ -51,7 +51,7 @@ def upsert_document(
                 raise ValueError("URL must not be None when content is None.")
             file_response = requests.get(url)
             content = file_response.text
-            
+
         with NamedTemporaryFile(suffix=".txt", delete=True) as temp_file:
             temp_file.write(file_response.text.encode())
             temp_file.flush()

--- a/app/lib/documents.py
+++ b/app/lib/documents.py
@@ -29,15 +29,16 @@ valid_ingestion_types = [
 
 
 def upsert_document(
-    url: str,
     type: str,
     document_id: str,
     from_page: int,
     to_page: int,
-    text_splitter: dict = None,
-    user_id: str = None,
-    authorization: dict = None,
-    metadata: dict = None,
+    url: str | None = None,
+    content: str | None = None,
+    text_splitter: dict | None = None,
+    user_id: str | None = None,
+    authorization: dict | None = None,
+    metadata: dict | None = None,
 ) -> None:
     """Upserts documents to Pinecone index"""
     pinecone.Index("superagent")
@@ -45,7 +46,12 @@ def upsert_document(
     embeddings = OpenAIEmbeddings()
 
     if type == "TXT":
-        file_response = requests.get(url)
+        if content is None:
+            if url is None:
+                raise ValueError("URL must not be None when content is None.")
+            file_response = requests.get(url)
+            content = file_response.text
+            
         with NamedTemporaryFile(suffix=".txt", delete=True) as temp_file:
             temp_file.write(file_response.text.encode())
             temp_file.flush()

--- a/app/lib/models/document.py
+++ b/app/lib/models/document.py
@@ -3,13 +3,14 @@ from pydantic import BaseModel, Field
 
 class Document(BaseModel):
     type: str
-    url: str = None
+    url: str | None = None
+    content: str | None = None
     name: str
-    authorization: dict = None
-    metadata: dict = None
-    from_page: int = (1,)
-    to_page: int = None
-    splitter: dict = None
+    authorization: dict | None = None
+    metadata: dict | None = None
+    from_page: int = 1
+    to_page: int | None = None
+    splitter: dict | None = None
 
 
 class DocumentInput(BaseModel):

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,8 @@ model Document {
   user          User            @relation(fields: [userId], references: [id])
   type          DocumentType    @default(TXT)
   url           String?         @db.Text()
+  content       String?         @db.Text()
+  contentHash   String?         @db.VarChar(255)
   name          String
   splitter      Json?
   createdAt     DateTime?       @default(now())


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->
There are some cases where data from the data pipeline should be loaded directly without using a URL. I have added the option to load data content directly in the text form.
Fixes

Depends on

## Test plan

<!-- Include the steps to test your PR -->
```
    def upload_to_database(self, name: str, content: str) -> str:
        try:
            logging.info(f"Uploading to database: {name}")
            document = self.superagent.client.documents.create_document(
                name=name,
                content=content,
                type="TXT",
            )
            return document.get("data", {}).get("id", "")
        except Exception as e:
            logging.error(f"Error occurred while uploading to database: {e}")
            return ""
```


## Screenshots

<!-- Include screenshots/videos (if any) of how the PR works -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
