### PR TITLE
Improve docker compose setup for different environments

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -19,34 +19,87 @@
    cp .docker/docker.example.env .docker/docker.env
    ```
 
-3. In order to connect to the db running in docker, with the example values from `docker.env`, set the following in the root `.env`. Set the `DATABASE_URL` and `DATABASE_MIGRATION_URL` to the same value and comment out, or remove the `DATABASE_SHADOW_URL`
+3. Set the NETWORK_HOST mode suitable for your setup:
+
+   ``` bash
+   # Default docker network, same as not having set NETWORK_HOST in docker-compose files. 
+   NETWORK_HOST=superagent_default
+
+   # Simulate running the docker resources on localhost
+   NETWORK_HOST=host
+
+   # Custom network, for some cloud deployments
+   NETWORK_HOST=mycustom_network_name
+   ```
+
+   If running `superagent_default` mode, you may need to add the docker host names for the services to your `hosts` file on Windows, then use these values in place of `localhost` or `127.0.0.1` in your `.env` files. This is especially needed when running the UI in docker as the browser will not be able to access the docker host, while the UI server code can.
+
+   - Open a text editor as admin (right click icon, 'Run as administrator')
+   - Open the file `C:\Windows\System32\drivers\etc\hosts`
+   - Add the following lines at the bottom
+
+   ``` bash
+   127.0.0.1		superagent-api
+   127.0.0.1		superagent-ui
+   127.0.0.1		pgdb
+   127.0.0.1		pgadmin
+   ```
+
+   You can then access any of these resources, running in docker, using these host names in your `.env` files and in the browser. e.g `http://superagent-ui:3000`, `http://superagent-api:8080`, `http://pgadmin:5050`
+
+4. In order to connect to the db running in docker, with the example values from `docker.env`, set the following in the root `.env`. Set the `DATABASE_URL` and `DATABASE_MIGRATION_URL` to the same value and comment out, or remove the `DATABASE_SHADOW_URL`
+
+   - root `.env`
 
     ``` bash
     # .env
-    DATABASE_URL=postgresql://admin:password@localhost:5432/superagent
+    # 'superbase_default' network mode
+    DATABASE_URL=postgresql://admin:password@pgdb:5432/superagent
+    DATABASE_MIGRATION_URL=postgresql://admin:password@pgdb:5432/superagent
+    # DATABASE_SHADOW_URL= # Mandatory for Neon DB
+
+    # 'host' network mode
+    DATABASE_URL=postgresql://admin:password@locahost:5432/superagent
     DATABASE_MIGRATION_URL=postgresql://admin:password@localhost:5432/superagent
     # DATABASE_SHADOW_URL= # Mandatory for Neon DB
+    ```
+
+    - `ui/.env`
+
+    ``` bash
+    # 'superbase_default' network mode
+    NEXTAUTH_URL="http://superagent-ui:3000"
+    NEXT_PUBLIC_SUPERAGENT_API_URL="http://superagent-api:8080/api/v1"
+
+    # 'host' network mode
+    NEXTAUTH_URL="http://localhost:3000"
+    NEXT_PUBLIC_SUPERAGENT_API_URL="http://127.0.0.1:8080/api/v1"
     ```
 
 ## Run Superagent with docker-compose
 
 After you have carefully set all the values in both the root `.env`, `ui/.env` and `.docker/docker.env` files, you can spin everything up in docker:
 
-### Run the UI. API and a Postgres DB together
+### Run API and a Postgres DB together
+
+The default `docker-compose.yml` file will run the API and a Postgres DB (including the PGAdmin tool), meaning you can run the UI either locally with npm or in docker seperately.
 
 ``` bash
 cd .docker
 docker-compose --env-file docker.env up --build -d
 
-# you can spin everything down with
-docker compose down
+# OR: Optionally also start the UI in docker too.
+docker-compose --env-file docker.env -f docker-compose.yml -f docker-compose.ui.yml up --build -d
 
-# It's often best to combine these and run this everytime to avoid issues
-docker compose down && docker-compose --env-file docker.env up --build -d
+# you can spin everything down with
+docker compose --env-file docker.env down
+
+# It's often best to make sure the last run is shut down everytime to avoid issues, combine down and up commands:
+docker compose --env-file docker.env down && docker-compose --env-file docker.env up --build -d
 
 ```
 
-### Run any single part individually or in combination with docker-compose.
+### Run any single part individually or in combination with docker-compose
 
 You can run just the bits you need in docker, meaning you can run the UI locally with npm, or the API with venv/conda locally to develop, while only running dependencies in docker for example.
 
@@ -64,11 +117,11 @@ docker-compose --env-file docker.env -f docker-compose.ui.yml up --build -d
 # Run just the API
 docker-compose --env-file docker.env -f docker-compose.api.yml up --build -d
 
-# Run the DB and the API together
-docker-compose --env-file docker.env -f docker-compose.pgdb.yml -f docker-compose.api.yml up --build -d
-
 # Run the DB and the UI together
 docker-compose --env-file docker.env -f docker-compose.pgdb.yml -f docker-compose.ui.yml up --build -d
+
+# Run everything, the DB, the API and the UI together
+docker-compose --env-file docker.env -f docker-compose.yml -f docker-compose.ui.yml up --build -d
 
 ```
 

--- a/.docker/docker-compose.api.yml
+++ b/.docker/docker-compose.api.yml
@@ -3,12 +3,14 @@ version: "3"
 services:
   superagent-api:
     container_name: superagent-api
-    network_mode: "host"
+    network_mode: ${NETWORK_MODE}
     build:
       context: ..
       dockerfile: Dockerfile
     command: ["/bin/bash", "setup.docker.sh"]
     environment:
       - PORT=8080
+    ports:
+      - 8080:8080
     env_file:
       - ../.env

--- a/.docker/docker-compose.pgdb.yml
+++ b/.docker/docker-compose.pgdb.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   pgdb:
     container_name: pgdb
-    network_mode: "host"
+    network_mode: ${NETWORK_MODE}
     image: postgres:12
     restart: unless-stopped
     volumes:
@@ -14,16 +14,25 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_USER: ${DBUSER}
       POSTGRES_PASSWORD: ${DBPASS}
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DBUSER}"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
 
   pgadmin:
     container_name: pgadmin
-    network_mode: "host"
+    network_mode: ${NETWORK_MODE}
     image: dpage/pgadmin4
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
       PGADMIN_LISTEN_ADDRESS: 0.0.0.0
       PGADMIN_LISTEN_PORT: 5050
+    ports:
+      - 5050:5050
     volumes:
       - type: volume
         source: pgadmin-data

--- a/.docker/docker-compose.ui.yml
+++ b/.docker/docker-compose.ui.yml
@@ -3,9 +3,13 @@ version: "3"
 services:
   superagent-ui:
     container_name: superagent-ui
-    network_mode: "host"
+    network_mode: ${NETWORK_MODE}
     build:
       context: ../ui
       dockerfile: Dockerfile
     env_file:
       - ../ui/.env
+    environment:
+      - PORT=3000
+    ports:
+      - 3000:3000

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,35 +1,29 @@
 version: "3"
 
 services:
-  superagent-ui:
-    container_name: superagent-ui
-    network_mode: "host"
-    build:
-      context: ../ui
-      dockerfile: Dockerfile
-    env_file:
-      - ../ui/.env
-    depends_on:
-      - superagent-api
-
   superagent-api:
     container_name: superagent-api
-    network_mode: "host"
+    network_mode: ${NETWORK_MODE}
     build:
       context: ..
       dockerfile: Dockerfile
     command: ["/bin/bash", "setup.docker.sh"]
     environment:
       - PORT=8080
+    ports:
+      - 8080:8080
     env_file:
       - ../.env
     depends_on:
-      - pgdb
-      - pgadmin
+      pgdb:
+        condition: service_healthy
+      pgadmin:
+        condition: service_started
+    restart: unless-stopped
 
   pgdb:
     container_name: pgdb
-    network_mode: "host"
+    network_mode: ${NETWORK_MODE}
     image: postgres:12
     restart: unless-stopped
     volumes:
@@ -40,10 +34,17 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_USER: ${DBUSER}
       POSTGRES_PASSWORD: ${DBPASS}
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DBUSER}"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
 
   pgadmin:
     container_name: pgadmin
-    network_mode: "host"
+    network_mode: ${NETWORK_MODE}
     image: dpage/pgadmin4
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}

--- a/.docker/docker.env.example
+++ b/.docker/docker.env.example
@@ -1,6 +1,13 @@
+# Network mode: Default docker network = 'superagent_default', same as not setting network mode:
+# Set "host" - simulate running the services on localhost [Not supported in Docker Desktop (win or mac), supported on linux, and windows with Rancher Desktop docker daemon]
+# Set 'your_custom_network_name' - option to use a custom network name to support cloud environments, replace with the actual network name
+NETWORK_MODE=superagent_default
+
+# postgres db login details, use in connection string e.g DATABASE_URL=postgresql://admin:password@pgdb:5432/superagent, http://pgdb:5432, or postgresql://admin:password@localhost:5432/superagent
 DBUSER=admin
 DBPASS=password
 DBNAME=superagent
 
+# Login details for pgadmin, http://localhost:5050 / http://pgadmin:5050
 PGADMIN_DEFAULT_EMAIL=dev@superagent.sh
 PGADMIN_DEFAULT_PASSWORD=password

--- a/.docker/run.docker.sh
+++ b/.docker/run.docker.sh
@@ -1,7 +1,6 @@
 ## To run everything in docker locally (UI, API, DB, etc.)
 
-docker-compose --env-file docker.env up --build -d
-
+docker compose down && docker-compose --env-file docker.env up --build -d
 ## When developing just the UI locally, you can run the following:
 ## This will only run the DB and API in docker
 ## You can then run the UI locally with `npm run dev`

--- a/README.md
+++ b/README.md
@@ -66,13 +66,11 @@ Superagent has first grade support for running on [Replit](https://replit.com). 
 
 In the `.docker` folder there are multiple docker-compose files.
 
-The main `docker-compose.yml` file can be used to build and setup everything needed to run superagent at once. This is the quickest way to run superagent locally. It includes both the API and UI, as well as a Postgres DB with the Adminer tool to administer it.
+The main `docker-conpose.yml` file will start up the API and a Postgres DB in docker. You can optionally also run the UI in docker too.
 
 The other docker compose files can be used individually, or in combination to start up just the bits you need.
 
-All the docker-compose files start up resources using the `network_mode: "host"` option to simulate running on localhost, this avoids any issues with container networking and makes sure each one can communicate with the others, even if you start up different parts seperately.
-
-> follow the guide in `.docker/README.md` file to get started
+> follow the guide in [.docker/README.md](.docker/README.md) file to get started
 
 ## 🌎 Environment variables
 


### PR DESCRIPTION
## Summary

Following on from #221, several improvements have been made to the docker-compose setup to support running on different OS/setups.

- Parameterise the `network_mode:` with a default of `superagent_default` that simulates the default networking that would be set if no `network_mode` option was set. 
-  Documented other networking options.
- Add healthcheck and depends_on conditions to properly wait for the db to be ready.
- remove UI from the default `docker-compose.yml` file, likely a more popular default. Can easily include the UI with another `-f docker-compose.ui.yml` flag.
- Updated documentation - incudes section on editing the windows host file to be able to use the docker host names locally.
- Main README now has an actual link to the docker README

Fixes

Depends on
Default docker networking  as default network mode.

## Test plan

Follow the updated guide in [.docker/README.md](.docker/README.md)