### PR TITLE
Fix cp command to reflect actual file name

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -12,11 +12,11 @@
    cp ui/.env.example ui/.env
    ```
 
-2. Copy the `.docker/docker.example.env` into a `docker.env` file.
+2. Copy the `.docker/docker.env.example` into a `docker.env` file.
 
    ``` bash
    # the example values are placeholders but they will work just fine locally.
-   cp .docker/docker.example.env .docker/docker.env
+   cp .docker/docker.env.example .docker/docker.env
    ```
 
 3. Set the NETWORK_HOST mode suitable for your setup:


### PR DESCRIPTION
running `cp .docker/docker.example.env .docker/docker.env` will fail because the file is actually named ` .docker/docker.env.example`

## Summary

<!-- Write a short description about your PR -->

There is a mismatch between the Readme and the actual filename for the docker compose instructions. The File is named `.docker/docker.env.example` and not `.docker/docker.example.env`.


Fixes

Changed the corresponding lines in the Readme.

Depends on

## Test plan

<!-- Include the steps to test your PR -->

-not needed

## Screenshots

<!-- Include screenshots/videos (if any) of how the PR works -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
