### PR TITLE
:herb: add response models

### DIFF
--- a/app/api/agent_documents.py
+++ b/app/api/agent_documents.py
@@ -6,6 +6,7 @@ from starlette.requests import Request
 from app.lib.auth.prisma import JWTBearer
 from app.lib.models.agent_document import AgentDocument
 from app.lib.prisma import prisma
+from response import Response
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -28,6 +29,7 @@ def parse_filter_params(request: Request):
     "/agent-documents",
     name="Create agent document",
     description="Create a agent document",
+    response_model=Response[AgentDocument],
 )
 async def create_agent_document(body: AgentDocument, token=Depends(JWTBearer())):
     """Create api token endpoint"""

--- a/app/api/agent_tools.py
+++ b/app/api/agent_tools.py
@@ -6,6 +6,7 @@ from starlette.requests import Request
 from app.lib.auth.prisma import JWTBearer
 from app.lib.models.agent_tool import AgentTool
 from app.lib.prisma import prisma
+from response import Response
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,7 @@ async def read_agent_tools(
     "/agent-tools/{agentToolId}",
     name="Get agent tool",
     description="Get a specific agent tool",
+    response_model=Response[AgentTool],
 )
 async def read_agent_tool(agentToolId: str, token=Depends(JWTBearer())):
     """Get an agent tool"""

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -16,6 +16,8 @@ from app.lib.auth.prisma import JWTBearer
 from app.lib.models.agent import Agent, PredictAgent
 from app.lib.prisma import prisma
 
+from .response import Response
+
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
@@ -73,6 +75,7 @@ async def read_agents(token=Depends(JWTBearer())):
     "/agents/library",
     name="List library agents",
     description="List all library agents",
+    response_model=Response[Agent]
 )
 async def read_library_agents(token=Depends(JWTBearer())):
     """Library agentsendpoint"""

--- a/app/api/response.py
+++ b/app/api/response.py
@@ -1,0 +1,10 @@
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel
+
+DataT = TypeVar('DataT')
+
+class Response(BaseModel, Generic[DataT]):
+    data: DataT
+    success: bool
+


### PR DESCRIPTION
## Summary

This PR shows an example of how to annotate FastAPI methods with response models. This will improve the generated OpenAPI and documentation. 


