### PR TITLE
Fix typos in readme

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -59,7 +59,7 @@
     # DATABASE_SHADOW_URL= # Mandatory for Neon DB
 
     # 'host' network mode
-    DATABASE_URL=postgresql://admin:password@locahost:5432/superagent
+    DATABASE_URL=postgresql://admin:password@localhost:5432/superagent
     DATABASE_MIGRATION_URL=postgresql://admin:password@localhost:5432/superagent
     # DATABASE_SHADOW_URL= # Mandatory for Neon DB
     ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To get started with Superagent, follow these steps:
 
 In the `.docker` folder there are multiple docker-compose files.
 
-The main `docker-conpose.yml` file will start up the API and a Postgres DB in docker. You can optionally also run the UI in docker too.
+The main `docker-compose.yml` file will start up the API and a Postgres DB in docker. You can optionally also run the UI in docker too.
 
 The other docker compose files can be used individually, or in combination to start up just the bits you need.
 


### PR DESCRIPTION
## Summary

While I was setting up project locally, I found couple of typos. One of them actually caused an issue while setting up docker(I copied env as it is for `host` network mode. In that `localhost` is misspelled as `locahost`)

Fixes

Depends on

## Test plan

<!-- Include the steps to test your PR -->

-

## Screenshots

<!-- Include screenshots/videos (if any) of how the PR works -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
