### PR TITLE
add openWhenHidden True to share/client-page.js

### DIFF
--- a/ui/app/share/client-page.js
+++ b/ui/app/share/client-page.js
@@ -296,6 +296,7 @@ export default function ShareClientPage({ agent, token }) {
           has_streaming: true,
           session: selectedSession.id,
         }),
+        openWhenHidden: true,
         async onmessage(event) {
           if (event.data !== "[END]") {
             message += event.data === "" ? `${event.data} \n` : event.data;


### PR DESCRIPTION
## Summary

This pull request addresses an issue where switching tabs would inadvertently start another stream while the /predict endpoint was already streaming, leading to duplicate agent runs.

- Added openWhenHidden: true option to the fetchEventSource function in ui/app/share/client-page.js.

Fixes
https://github.com/homanp/superagent/issues/310

Depends on

## Test plan

This change has been manually tested by switching tabs while the /predict endpoint is streaming. The results confirm that a new stream is not started upon returning to the original tab.

## Screenshots
Before:
<img width="505" alt="Screenshot 2023-08-22 at 7 09 59 PM" src="https://github.com/homanp/superagent/assets/2533394/52ba9cf8-6c1c-473a-9ada-a9c3494ecaf5">


After:
<img width="571" alt="Screenshot 2023-08-22 at 7 08 01 PM" src="https://github.com/homanp/superagent/assets/2533394/70a07c77-3081-4be4-81ee-93e18d2d8021">

https://github.com/Azure/fetch-event-source/issues/35



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `make format`.
- [] My change requires a change to the documentation.
- [] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [x] My change has adequate unit test coverage.
