### PR TITLE
:herb: Upgrade python sdk generator to `0.4.4`

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -2,7 +2,7 @@ groups:
   publish:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 0.4.1
+        version: 0.4.4
         output:
           location: pypi
           package-name: superagent-py


### PR DESCRIPTION
The python generator for `0.4.4` has a bug fix for downloading poetry.
