### PR TITLE
:herb: Update background color for Fern Docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,6 +14,7 @@ navigation:
   - api: API Reference
 colors:
   accentPrimary: "#FDC537"
+  background: "#0F1117"
 logo:
   dark: ./assets/logo-dark.png
   height: 24


### PR DESCRIPTION
This PR will give the docs a solid black background by default which will make the yellow pop out more (as opposed to the existing CSS gradient). 