### PR TITLE
:herb: Rename versions to `v1` and `v0`

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -9,12 +9,13 @@ logo:
   height: 24
   href: https://www.superagent.sh/
 versions: 
-  - display-name: legacy
-    path: ./versions/legacy.yml
-    slug: v0.0.X
-  - display-name: v0.0.99
+  - display-name: v1
     path: ./versions/prod.yml
-    slug: v0.0.99
+    slug: v1
+  - display-name: v0
+    path: ./versions/legacy.yml
+    slug: v0
+    availability: deprecated
 favicon: ./assets/favicon.png
 title: Superagent | Docs
 navbar-links:


### PR DESCRIPTION
Updates the version in docs to be `v1` and `v0`