### PR TITLE
Revert fern ci to only trigger on tag release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
   fern-generate:
     needs: fern-check
-    #if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -34,7 +34,7 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: fern generate --group publish --log-level debug --version v0.1.1 --api prod
+        run: fern generate --group publish --log-level debug --version ${{ github.ref_name }} --api prod
       
       - name: Update Docs
         env:


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

This PR reverts the Fern CI to only trigger on tagged releases.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
