### PR TITLE
Fix broken link to LangSmith

### DIFF
--- a/fern/mdx/concepts.mdx
+++ b/fern/mdx/concepts.mdx
@@ -82,7 +82,7 @@ These models are the driving force behind the Agent's ability to engage in meani
 
 ### Tracing
 
-Superagent employs a powerful tool called [LangSmith](smith.langchain.com/) for tracing and debugging Agent runs. 
+Superagent employs a powerful tool called [LangSmith](https://docs.smith.langchain.com/) for tracing and debugging Agent runs. 
 LangSmith is a state-of-the-art tracing system that provides detailed insights into the execution of an Agent. 
 It records the sequence of operations performed by the Agent, including the interaction with datasources and tools, and the decisions made based on user input. 
 This allows developers to track the flow of data and the decision-making process of the Agent, making it easier to identify and fix issues.


### PR DESCRIPTION
## Summary

Fixes broken link to LangSmith in fern/libs/concepts.mdx

Depends on

## Test plan

- Link to LangSmith in [Tracing](https://docs.superagent.sh/%5Bhost%5D/tracing) section should work.


## Screenshots

<!-- Include screenshots/videos (if any) of how the PR works -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
