### PR TITLE
docs: fix typo in fern/mdx/authentication.mdx

### DIFF
--- a/fern/mdx/authentication.mdx
+++ b/fern/mdx/authentication.mdx
@@ -4,7 +4,7 @@ Superagent uses API keys to authenticate requests. You can manage API keys using
 
 As API keys carry many privileges such as creating and destroying agents, it is important to keep them private and secure. Do not hardcode or share API keys (particularly in your source version control system), and they should only be used in your backend.
 
-Authentication is handled via HTTP headers, specifically the `Authorizaton` header. 
+Authentication is handled via HTTP headers, specifically the `Authorization` header. 
 
 ```bash
 curl -X POST 'https://api.beta.superagent.sh/api/v1<ENDPOINT>' \


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

This pull request fixes typo `Authorizaton -> Authorization` in `fern/mdx/authentication.mdx`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `make format`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [x] My change has adequate unit test coverage.
