### PR TITLE
Update Fern generator versions

### DIFF
--- a/fern/apis/prod/generators.yml
+++ b/fern/apis/prod/generators.yml
@@ -2,7 +2,7 @@ groups:
   publish:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 0.6.2
+        version: 0.6.6
         output:
           location: pypi
           package-name: superagent-py
@@ -12,7 +12,7 @@ groups:
         config:
           client_class_name: Superagent
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.7.1
+        version: 0.8.8
         output:
           location: npm
           package-name: superagentai-js
@@ -21,7 +21,3 @@ groups:
           repository: homanp/superagent-js
         config:
           namespaceExport: SuperAgent
-  prod-docs:
-    docs:
-      domain: superagent.docs.buildwithfern.com
-    generators: []


### PR DESCRIPTION
## Summary

This updates the Fern generators used to produce the JavaScript and Python SDKs to the latest versions. It also removes an unnecessary config that is not deprecated.

Fixes

Python SDK compile failure.


## Test plan

`fern check` should pass. Then the checks in the JS and Python repo should pass.

- [x] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
