### PR TITLE
Guard agains malformed json input for custom functions

### DIFF
--- a/libs/ui/app/apis/columns.tsx
+++ b/libs/ui/app/apis/columns.tsx
@@ -206,7 +206,25 @@ export function EditTool({
                             className="rounded-lg text-xs"
                             extensions={[json()]}
                             theme={vscodeDark}
-                            onChange={field.onChange}
+                            onChange={(value) => {
+                              try {
+                                // Attempt to parse the JSON
+                                JSON.parse(value)
+                                // If successful, update the field value
+                                field.onChange(value)
+                                // Optionally, clear any previous JSON error message
+                                form.clearErrors(
+                                  `metadata.${metadataField.key}`
+                                )
+                              } catch (error) {
+                                // If there's a JSON parse error, set a form error
+                                console.log(error)
+                                form.setError(`metadata.${metadataField.key}`, {
+                                  type: "manual",
+                                  message: "Invalid JSON",
+                                })
+                              }
+                            }}
                             value={field.value}
                           />
                         </div>


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

Fixes an issue with the user being able to save a malformed JSON when setting up a custom function in UI.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
