### PR TITLE
Add directUrl to schema.prisma

### DIFF
--- a/libs/superagent/prisma/schema.prisma
+++ b/libs/superagent/prisma/schema.prisma
@@ -6,6 +6,7 @@ generator client {
 datasource db {
   provider          = "postgresql"
   url               = env("DATABASE_URL")
+  directUrl         = env("DATABASE_MIGRATION_URL")
   shadowDatabaseUrl = env("DATABASE_SHADOW_URL")
 }
 


### PR DESCRIPTION
## Summary

Add directUrl to schema.prisma

Fixes

Prisma migration error "prepared statement \\"s0\\" already exists\"
