### PR TITLE
Adding auth script to db migrations

### DIFF
--- a/fern/mdx/deploy/local.mdx
+++ b/fern/mdx/deploy/local.mdx
@@ -134,28 +134,7 @@ supabase migration up
 supabase db push
 ```
 
-5. Run the following query to setup authentication:
-```bash 
--- inserts a row into public.profiles
-create function public.handle_new_user()
-returns trigger
-language plpgsql
-security definer set search_path = public
-as $$
-begin
-insert into public.profiles (user_id)
-values (new.id);
-return new;
-end;
-$$;
-
--- trigger the function every time a user is created,
-create trigger on_auth_user_created
-after insert on auth.users
-for each row execute procedure public.handle_new_user();
-```
-
-6. Create a [Supabase storage](https://supabase.com/docs/guides/storage) with the following `storage.objects` permissions:
+5. Create a [Supabase storage](https://supabase.com/docs/guides/storage) with the following `storage.objects` permissions:
 <img width="2672" alt="Screenshot 2023-09-14 at 23 27 35" src="https://github.com/homanp/superagent/assets/2464556/8d6bde18-528e-4e0a-9840-aabe39ce5e68" />
 
 ### Setup authentication

--- a/libs/ui/supabase/migrations/20231223183054_auth_script.sql
+++ b/libs/ui/supabase/migrations/20231223183054_auth_script.sql
@@ -1,0 +1,17 @@
+-- inserts a row into public.profiles
+create function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer set search_path = public
+as $$
+begin
+insert into public.profiles (user_id)
+values (new.id);
+return new;
+end;
+$$;
+
+-- trigger the function every time a user is created,
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute procedure public.handle_new_user();


### PR DESCRIPTION
## Summary

This PR aims to improve docs. I am adding the required auth script to database migrations.

- [x] My code follows the code style of this project and passes `make format`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
