### PR TITLE
Replace Python snippet with JavaScript

### DIFF
--- a/fern/mdx/sdk/chat_with_tools.mdx
+++ b/fern/mdx/sdk/chat_with_tools.mdx
@@ -50,7 +50,7 @@ Note that you usually only need to create the `llm` object once and re-use it f
 
         const {data: llm} = await client.llm.create({
             provider: "OPENAI",
-            apiKey: os.environ["OPENAI_API_KEY"]
+            apiKey: process.env.OPENAI_API_KEY
         })
 
         const {data: agent} = await client.agent.create({


### PR DESCRIPTION
## Summary
I've updated the documentation and replaced the Python snippet `os.environ..` from the Javascript script.

- [x] My code follows the code style of this project and passes `make format`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
