### PR TITLE
Add `returnDirect` property to tool creation

### DIFF
--- a/fern/mdx/sdk/chat_with_tools.mdx
+++ b/fern/mdx/sdk/chat_with_tools.mdx
@@ -79,6 +79,7 @@ Note that you usually only need to create the `llm` object once and re-use it f
             "description": "A portal to the internet, useful for answering questions about websites or urls.",
             "type": "BROWSER",
             # "metadata": {"key": "value"} Optional metadata for the tool. 
+            "returnDirect": false, # returnDirect is required while creating a tool.
         })
 
         client.agent.add_tool(agent_id=agent.data.id, tool_id=tool.data.id)
@@ -90,6 +91,7 @@ Note that you usually only need to create the `llm` object once and re-use it f
             name: "Browser",
             description: "A portal to the internet, useful for answering questions about websites or urls.",
             type: "BROWSER",
+            returnDirect: false, // returnDirect is required for creating a tool.
         })
 
         await client.agent.addTool(agent.id, {
@@ -161,6 +163,7 @@ That's it! Tools are super powerful way ginving your Assistants super powers. We
             "description": "A portal to the internet, useful for answering questions about websites or urls.",
             "type": "BROWSER",
             # "metadata": {"key": "value"} Optional metadata for the tool. 
+            "returnDirect": false,
         })
 
         client.agent.add_llm(agent_id=agent.data.id, llm_id=llm.data.id)
@@ -204,6 +207,7 @@ That's it! Tools are super powerful way ginving your Assistants super powers. We
             name: "Browser",
             description: "A portal to the internet, useful for answering questions about websites or urls.",
             type: "BROWSER",
+            returnDirect: false,
         })
 
         await client.agent.addLlm(agent.id, {


### PR DESCRIPTION
## Summary
I've added the required field i.e. `returnDirect` in the tool creation params.
## Checklist

- [x] My code follows the code style of this project and passes `make format`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
