### PR TITLE
Feature: reusable alert dialogue component (#615)

### DIFF
--- a/libs/ui/app/agents/[agentId]/header.tsx
+++ b/libs/ui/app/agents/[agentId]/header.tsx
@@ -23,6 +23,7 @@ import { FormLabel } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { Toaster } from "@/components/ui/toaster"
 import { useToast } from "@/components/ui/use-toast"
+import { AlertDialogDemo } from "@/components/alert-dialog-demo"
 
 const baseUrl =
   process.env.NODE_ENV === "production"
@@ -74,9 +75,12 @@ Superagent({
       <div className="flex items-center justify-between border-b px-4 py-3">
         <p className="text-lg">{agent.name}</p>
         <div className="flex space-x-2">
-          <Button size="sm" variant="secondary" onClick={() => handleDelete()}>
-            <TbTrashX size="18px" />
-          </Button>
+          <AlertDialogDemo alertActionHandler={handleDelete} alertAction="Delete" alertDescription="This action cannot be undone. This will permanently delete the agent
+            and remove your data from our servers." >
+            <Button size="sm" variant="secondary">
+              <TbTrashX size="18px" />
+            </Button>
+          </AlertDialogDemo>
           <Button
             size="sm"
             variant="secondary"

--- a/libs/ui/components/alert-dialog-demo.tsx
+++ b/libs/ui/components/alert-dialog-demo.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+
+type AlertDialogProps = {
+    children: React.ReactNode
+    alertTitle?: string
+    alertDescription?: string
+    alertAction?: string
+    alertActionHandler?: () => void
+}
+
+export function AlertDialogDemo({children, alertTitle, alertDescription, alertAction, alertActionHandler}: AlertDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        {children}
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{alertTitle || "Are you absolutely sure?"}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {alertDescription || "This action cannot be undone. This will permanently delete your account and remove your data from our servers."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={alertActionHandler}>{alertAction || "Continue"}</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}


### PR DESCRIPTION
## Summary

Show confirmation dialog when a user tries to delete an agent. And make the alert dialogue component reusable

Fixes #615

Depends on

## Test plan

<!-- Include the steps to test your PR -->

-

## Screenshots

https://github.com/homanp/superagent/assets/72187009/fd78bbf1-4d7b-43e8-a0a3-db58c15d6ee8


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
