### PR TITLE
Add fix for returning non JSON responses from HTTP tool

### DIFF
--- a/libs/superagent/app/tools/http.py
+++ b/libs/superagent/app/tools/http.py
@@ -16,13 +16,17 @@ class LCHttpTool(LCBaseTool):
             if self.metadata.get("headers")
             else {}
         )
+        headers["content-type"] = "application/json"
         try:
             request_kwargs = {"method": method, "url": url, "headers": headers}
             if body is not None:
                 request_kwargs["json"] = body
             response = requests.request(**request_kwargs)
             response.raise_for_status()
-            return response.json()
+            try:
+                return response.json()
+            except Exception:
+                return "Request successful"
         except requests.exceptions.RequestException as e:
             return str(e)
 
@@ -32,12 +36,16 @@ class LCHttpTool(LCBaseTool):
             if self.metadata.get("headers")
             else {}
         )
+        headers["content-type"] = "application/json"
         try:
             async with aiohttp.ClientSession() as session:
                 request_kwargs = {"method": method, "url": url, "headers": headers}
                 if body is not None:
                     request_kwargs["json"] = body
                 async with session.request(**request_kwargs) as response:
-                    return await response.json()
+                    try:
+                        return await response.json()
+                    except Exception:
+                        return "Request successfull"
         except Exception as e:
             return str(e)


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

Fixes an issue with HTTP tool returning exception when request returns non json content.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
