### PR TITLE
feat(request-model): Make `returnDirect` required

### DIFF
--- a/libs/superagent/app/models/request.py
+++ b/libs/superagent/app/models/request.py
@@ -46,7 +46,7 @@ class Tool(BaseModel):
     description: str
     type: str
     metadata: Optional[Dict[Any, Any]]
-    returnDirect: Optional[bool]
+    returnDirect: bool
 
 
 class AgentTool(BaseModel):


### PR DESCRIPTION
## Summary
Made `returnDirect` required instead of optional.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
