### PR TITLE
Fix typo in default prompts

### DIFF
--- a/libs/superagent/app/agents/base.py
+++ b/libs/superagent/app/agents/base.py
@@ -5,7 +5,7 @@ from app.utils.streaming import CustomAsyncIteratorCallbackHandler
 from prisma.models import Agent, AgentDatasource, AgentLLM, AgentTool
 
 DEFAULT_PROMPT = (
-    "You are a helpful AI Assistant, anwer the users questions to "
+    "You are a helpful AI Assistant, answer the users questions to "
     "the best of your ability."
 )
 

--- a/libs/superagent/app/agents/langchain.py
+++ b/libs/superagent/app/agents/langchain.py
@@ -22,7 +22,7 @@ from app.utils.llm import LLM_MAPPING
 from prisma.models import Agent, AgentDatasource, AgentLLM, AgentTool
 
 DEFAULT_PROMPT = (
-    "You are a helpful AI Assistant, anwer the users questions to "
+    "You are a helpful AI Assistant, answer the users questions to "
     "the best of your ability."
 )
 


### PR DESCRIPTION
## Summary

<!-- Write a short description about your PR -->

Fixes two typos for the DEFAULT_PROMPT

Depends on

## Test plan

None

-

## Screenshots

None

## Checklist


- [x] My code follows the code style of this project and passes `make format`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://docs.superagent.sh/) accordingly.
- [ ] My change has adequate unit test coverage.
