### PR TITLE
New Datasource Schema in SAML

### DIFF
--- a/libs/superagent/app/agents/llm.py
+++ b/libs/superagent/app/agents/llm.py
@@ -9,7 +9,6 @@ class LLMAgent(AgentBase):
     async def get_agent(self):
         enable_streaming = self.enable_streaming
         agent_config = self.agent_config
-        print(agent_config)
 
         class CustomAgentExecutor:
             async def ainvoke(self, input, *_, **kwargs):

--- a/libs/superagent/app/api/workflow_configs/api/api_datasource_manager.py
+++ b/libs/superagent/app/api/workflow_configs/api/api_datasource_manager.py
@@ -1,0 +1,126 @@
+import logging
+
+from app.api.agents import (
+    add_datasource as api_add_agent_datasource,
+)
+from app.api.datasources import (
+    create as api_create_datasource,
+)
+from app.api.datasources import (
+    delete as api_delete_datasource,
+)
+from app.api.workflow_configs.api.base import (
+    BaseApiAgentManager,
+    BaseApiDatasourceManager,
+)
+from app.models.request import (
+    AgentDatasource as AgentDatasourceRequest,
+)
+from app.models.request import (
+    Datasource as DatasourceRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ApiDatasourceManager(BaseApiDatasourceManager):
+    """
+    Class for managing datasources.
+    """
+
+    def __init__(self, api_user, agent_manager: BaseApiAgentManager):
+        self.api_user = api_user
+        self.agent_manager = agent_manager
+
+    # for ensuring unique datasource names
+    def _get_datasource_name(
+        self, file_type: str, file_url: str, description: str
+    ) -> str:
+        return f"{file_type} doc {description} - {file_url}"
+
+    async def create_datasource(self, data: dict):
+        try:
+            res = await api_create_datasource(
+                body=DatasourceRequest.parse_obj(data),
+                api_user=self.api_user,
+            )
+
+            new_datasource = res.get("data", {})
+
+            logger.info(f"Created datasource: {data}")
+            return new_datasource
+        except Exception:
+            logger.error(f"Error creating datasource: {data}")
+
+    async def add_datasource(self, assistant: dict, data: dict):
+        assistant = await self.agent_manager.get_assistant(assistant)
+
+        files = data.get("files", [])
+
+        for file in files:
+            file_url = file.get("url")
+            file_type = file.get("type")
+            description = data.get("description")
+
+            datasource_data = {
+                "name": self._get_datasource_name(
+                    file_type,
+                    file_url,
+                    description,
+                ),
+                "description": description,
+                "url": file_url,
+                "type": file_type,
+            }
+
+            new_datasource = await self.create_datasource(datasource_data)
+
+            try:
+                await api_add_agent_datasource(
+                    agent_id=assistant.id,
+                    body=AgentDatasourceRequest(
+                        datasourceId=new_datasource.id,
+                    ),
+                    api_user=self.api_user,
+                )
+                logger.info(
+                    f"Added datasource: {new_datasource.name} - {assistant.name}"
+                )
+            except Exception:
+                logger.error(f"Error adding datasource: {new_datasource} - {assistant}")
+
+    async def delete_datasource(self, assistant: dict, datasource: dict):
+        assistant = await self.agent_manager.get_assistant(assistant)
+        files = datasource.get("files", [])
+
+        for file in files:
+            try:
+                datasource = {
+                    "name": self._get_datasource_name(
+                        file_type=file.get("type"),
+                        file_url=file.get("url"),
+                        description=datasource.get("description"),
+                    ),
+                }
+
+                datasource = await self.agent_manager.get_datasource(
+                    assistant, datasource
+                )
+                await api_delete_datasource(
+                    datasource_id=datasource.id,
+                    api_user=self.api_user,
+                )
+                logger.info(f"Deleted datasource: {datasource.name} - {assistant.name}")
+            except Exception:
+                logger.error(f"Error deleting datasource: {datasource} - {assistant}")
+
+    async def update_datasource(
+        self, assistant: dict, old_datasource: dict, new_datasource: dict
+    ):
+        try:
+            await self.delete_datasource(assistant, old_datasource)
+            await self.add_datasource(assistant, new_datasource)
+        except Exception:
+            logger.error(
+                f"Error updating datasource: {old_datasource} - {new_datasource}"
+            )

--- a/libs/superagent/app/api/workflow_configs/api/api_manager.py
+++ b/libs/superagent/app/api/workflow_configs/api/api_manager.py
@@ -24,7 +24,7 @@ from app.models.request import (
 from app.utils.prisma import prisma
 from app.vectorstores.base import vector_db_mapping
 
-from .base import BaseApiAgentManager, BaseApiDatasourceManager
+from .base import BaseApiAgentManager
 
 logger = logging.getLogger(__name__)
 
@@ -34,11 +34,9 @@ class ApiManager:
         self,
         api_user,
         agent_manager: BaseApiAgentManager,
-        datasource_manager: BaseApiDatasourceManager,
     ):
         self.api_user = api_user
         self.agent_manager = agent_manager
-        self.datasource_manager = datasource_manager
 
     async def update_tool(
         self,

--- a/libs/superagent/app/api/workflow_configs/api/base.py
+++ b/libs/superagent/app/api/workflow_configs/api/base.py
@@ -34,3 +34,24 @@ class BaseApiAgentManager(ABC):
     @abstractmethod
     async def update_assistant(self, assistant: dict, data: dict):
         pass
+
+
+class BaseApiDatasourceManager(ABC):
+    """
+    Abstract class for managing datasources.
+    It can be Naive RAG or Super RAG
+    """
+
+    @abstractmethod
+    async def add_datasource(self, assistant: dict, data: dict):
+        pass
+
+    @abstractmethod
+    async def delete_datasource(self, assistant: dict, datasource: dict):
+        pass
+
+    @abstractmethod
+    async def update_datasource(
+        self, assistant: dict, old_datasource: dict, new_datasource: dict
+    ):
+        pass

--- a/libs/superagent/app/api/workflow_configs/data_transformer.py
+++ b/libs/superagent/app/api/workflow_configs/data_transformer.py
@@ -1,13 +1,24 @@
+import logging
+
+from app.api.workflow_configs.api.api_manager import ApiManager
 from app.utils.helpers import (
+    MIME_TYPE_TO_EXTENSION,
+    get_mimetype_from_url,
     remove_key_if_present,
     rename_and_remove_keys,
 )
 from app.utils.llm import LLM_REVERSE_MAPPING, get_llm_provider
 
-from .saml_schema import WorkflowTool
+from .saml_schema import WorkflowDatasource, WorkflowTool
+
+logger = logging.getLogger(__name__)
 
 
 class DataTransformer:
+    def __init__(self, api_user, api_manager: ApiManager):
+        self.api_user = api_user
+        self.api_manager = api_manager
+
     @staticmethod
     def transform_tool(tool: WorkflowTool, tool_type: str):
         rename_and_remove_keys(tool, {"use_for": "description"})
@@ -50,3 +61,65 @@ class DataTransformer:
 
         if assistant.get("type") == "LLM":
             remove_key_if_present(assistant, "llmModel")
+
+    async def transform_data(self, data: dict[str, WorkflowDatasource]):
+        for datasource_name, datasource in data.items():
+            rename_and_remove_keys(datasource, {"use_for": "description"})
+
+            files = []
+            for url in datasource.get("urls", []):
+                file_type = MIME_TYPE_TO_EXTENSION.get(get_mimetype_from_url(url))
+
+                if file_type:
+                    files.append(
+                        {
+                            "type": file_type,
+                            "url": url,
+                        }
+                    )
+                else:
+                    logger.warning(
+                        f"Could not determine file type for {url}. Skipping..."
+                    )
+
+            datasource["files"] = files
+
+            remove_key_if_present(datasource, "urls")
+
+            database_provider = datasource.get("database_provider")
+
+            if database_provider:
+                provider = await self.api_manager.get_vector_database_by_provider(
+                    database_provider
+                )
+
+                # this is for superrag
+                if provider:
+                    credential_keys_mapping = {
+                        # pinecone
+                        "PINECONE_API_KEY": "api_key",
+                        # qdrant
+                        "QDRANT_API_KEY": "api_key",
+                        "QDRANT_HOST": "host",
+                        # weaviate
+                        "WEAVIATE_API_KEY": "api_key",
+                        "WEAVIATE_URL": "host",
+                    }
+
+                    options = provider.options
+
+                    config = {}
+                    if options:
+                        for key, value in options.items():
+                            new_key = credential_keys_mapping.get(key)
+                            if new_key:
+                                config[new_key] = value
+
+                    datasource["vector_database"] = {
+                        "type": database_provider,
+                        "config": config,
+                    }
+
+                remove_key_if_present(datasource, "database_provider")
+
+            datasource["index_name"] = datasource_name

--- a/libs/superagent/app/api/workflow_configs/processors/agent_processor.py
+++ b/libs/superagent/app/api/workflow_configs/processors/agent_processor.py
@@ -32,7 +32,7 @@ class AgentProcessor:
         old_tools = old_assistant.get("tools") or []
         new_tools = new_assistant.get("tools") or []
 
-        dt = DataTransformer()
+        dt = DataTransformer(api_user=self.api_user, api_manager=self.api_manager)
         dt.transform_assistant(new_assistant, new_type)
         dt.transform_assistant(old_assistant, old_type)
 
@@ -47,6 +47,9 @@ class AgentProcessor:
             tool = tool.get(tool_type, {})
 
             dt.transform_tool(tool, tool_type)
+
+        await dt.transform_data(old_data)
+        await dt.transform_data(new_data)
 
         if old_assistant:
             old_tool_processor = Processor(
@@ -64,6 +67,7 @@ class AgentProcessor:
             new_data_processor = Processor(
                 self.api_user, self.api_manager
             ).get_data_processor(new_assistant)
+
         if old_type and new_type:
             if old_type != new_type:
                 # order matters here as we need process

--- a/libs/superagent/app/api/workflow_configs/processors/base.py
+++ b/libs/superagent/app/api/workflow_configs/processors/base.py
@@ -8,9 +8,11 @@ class BaseProcessor(ABC):
         self,
         assistant: dict,
         api_manager: ApiManager,
+        api_user,
     ):
         self.assistant = assistant
         self.api_manager = api_manager
+        self.api_user = api_user
 
     @abstractmethod
     async def process(self, old_data, new_data):

--- a/libs/superagent/app/api/workflow_configs/processors/processor.py
+++ b/libs/superagent/app/api/workflow_configs/processors/processor.py
@@ -19,10 +19,10 @@ class Processor:
 
     def get_data_processor(self, assistant: dict) -> BaseProcessor:
         if assistant.get("type") == AgentType.OPENAI_ASSISTANT:
-            return OpenaiDataProcessor(assistant, self.api_manager)
-        return SuperagentDataProcessor(assistant, self.api_manager)
+            return OpenaiDataProcessor(assistant, self.api_manager, self.api_user)
+        return SuperagentDataProcessor(assistant, self.api_manager, self.api_user)
 
     def get_tool_processor(self, assistant: dict) -> BaseProcessor:
         if assistant.get("type") == AgentType.OPENAI_ASSISTANT:
-            return OpenaiToolProcessor(assistant, self.api_manager)
-        return SuperagentToolProcessor(assistant, self.api_manager)
+            return OpenaiToolProcessor(assistant, self.api_manager, self.api_user)
+        return SuperagentToolProcessor(assistant, self.api_manager, self.api_user)

--- a/libs/superagent/app/api/workflow_configs/saml_schema.py
+++ b/libs/superagent/app/api/workflow_configs/saml_schema.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel
 class WorkflowDatasource(BaseModel):
     use_for: Optional[str]  # an alias for description
     urls: Optional[List[str]]
+    database_provider: Optional[str]  # for superrag
+    encoder: Optional[str]  # for superrag
 
 
 class WorkflowTool(BaseModel):
@@ -21,7 +23,7 @@ class WorkflowAssistant(BaseModel):
     intro: Optional[str]  # an alias for initialMessage
 
     tools: Optional[List[Dict[str, WorkflowTool]]]
-    data: Optional[WorkflowDatasource]
+    data: Optional[Dict[str, WorkflowDatasource]]
 
 
 class WorkflowAssistantAsTool(WorkflowAssistant):

--- a/libs/superagent/app/api/workflow_configs/workflow_configs.py
+++ b/libs/superagent/app/api/workflow_configs/workflow_configs.py
@@ -7,6 +7,7 @@ from decouple import config
 from fastapi import APIRouter, Body, Depends, HTTPException
 
 from app.api.workflow_configs.api.api_agent_manager import ApiAgentManager
+from app.api.workflow_configs.api.api_datasource_manager import ApiDatasourceManager
 from app.api.workflow_configs.api.api_manager import ApiManager
 from app.utils.api import get_current_api_user, handle_exception
 from app.utils.prisma import prisma
@@ -45,7 +46,8 @@ async def add_config(
         old_config = {} if not workflow_config else workflow_config.config
 
         agent_manager = ApiAgentManager(workflow_id, api_user)
-        api_manager = ApiManager(api_user, agent_manager)
+        datasource_manager = ApiDatasourceManager(api_user, agent_manager)
+        api_manager = ApiManager(api_user, agent_manager, datasource_manager)
         processor = AgentProcessor(api_user, api_manager)
         await processor.process_assistants(old_config, new_config)
 

--- a/libs/superagent/app/api/workflow_configs/workflow_configs.py
+++ b/libs/superagent/app/api/workflow_configs/workflow_configs.py
@@ -7,7 +7,6 @@ from decouple import config
 from fastapi import APIRouter, Body, Depends, HTTPException
 
 from app.api.workflow_configs.api.api_agent_manager import ApiAgentManager
-from app.api.workflow_configs.api.api_datasource_manager import ApiDatasourceManager
 from app.api.workflow_configs.api.api_manager import ApiManager
 from app.utils.api import get_current_api_user, handle_exception
 from app.utils.prisma import prisma
@@ -46,8 +45,7 @@ async def add_config(
         old_config = {} if not workflow_config else workflow_config.config
 
         agent_manager = ApiAgentManager(workflow_id, api_user)
-        datasource_manager = ApiDatasourceManager(api_user, agent_manager)
-        api_manager = ApiManager(api_user, agent_manager, datasource_manager)
+        api_manager = ApiManager(api_user, agent_manager)
         processor = AgentProcessor(api_user, api_manager)
         await processor.process_assistants(old_config, new_config)
 

--- a/libs/ui/config/saml.ts
+++ b/libs/ui/config/saml.ts
@@ -4,15 +4,17 @@ export const initialSamlValue = `# 👋 Welcome! Start creating your workflows u
 # More info in our docs: https://docs.superagent.sh/overview/getting-started/super-agent-markup-language
 
 workflows:
-  - superagent: 
-      name: Earnings assistant
+  - superagent:
       llm: gpt-4-1106-preview
-      prompt: Use the earnings report to answer any questions
+      data:
+        earnings:
+          urls:
+            - https://s2.q4cdn.com/299287126/files/doc_financials/2023/q3/AMZN-Q3-2023-Earnings-Release.pdf
+          use_for: Answering questions about earning report
+          database: pinecone
+      name: Earnings assistant
       intro: 👋 Hi there! How can I help you?
-      data: # This is for structured and unstructured data
-        use_for: Answering questions about earning reports
-        urls:
-          - "https://s2.q4cdn.com/299287126/files/doc_financials/2023/q3/AMZN-Q3-2023-Earnings-Release.pdf"
+      prompt: Use the earnings report to answer any questions
 `
 
 export const exampleConfigs = {


### PR DESCRIPTION
## Warning
*This is a breaking change, we need to migrate existing data*


## Tasks:
- [ ] update example SAMLs to conform new schema

## Summary

This PR changes SAML schema for datasources.  (this changes is needed for to support superrag).

Here's an example of new database schema:

```yaml
workflows:
  - superagent:
      llm: gpt-4-1106-preview
      data:
        earnings:
          urls:
            - https://s2.q4cdn.com/299287126/files/doc_financials/2023/q3/AMZN-Q3-2023-Earnings-Release.pdf
          use_for: Answering questions about earning report
      name: Earnings assistant
      intro: 👋 Hi there! How can I help you?
      prompt: Use the earnings report to answer any questions
```





Fixes #785