### PR TITLE
Fixing naming confusion in SAML

### DIFF
--- a/libs/superagent/app/api/workflow_configs/data_transformer.py
+++ b/libs/superagent/app/api/workflow_configs/data_transformer.py
@@ -1,6 +1,7 @@
 import logging
 
 from app.api.workflow_configs.api.api_manager import ApiManager
+from app.api.workflow_configs.saml_schema import SAML_OSS_LLM_PROVIDERS
 from app.utils.helpers import (
     get_first_non_null_key,
     get_mimetype_from_url,
@@ -89,6 +90,9 @@ class DataTransformer:
         )
 
         if self.assistant_type:
+            if self.assistant_type.upper() in SAML_OSS_LLM_PROVIDERS:
+                self.assistant_type = AgentType.LLM.value
+
             self.assistant["type"] = self.assistant_type.upper()
 
         llm_model = self.assistant.get("llmModel")

--- a/libs/superagent/app/api/workflow_configs/processors/agent_processor.py
+++ b/libs/superagent/app/api/workflow_configs/processors/agent_processor.py
@@ -54,6 +54,10 @@ class AgentProcessor:
         await old_saml_transformer.transform()
         await new_saml_transformer.transform()
 
+        # this is needed because type can be changed in data transformer
+        old_assistant_type = old_assistant.get("type")
+        new_assistant_type = new_assistant.get("type")
+
         if old_assistant:
             old_tool_processor = Processor(
                 self.api_user,

--- a/libs/superagent/app/api/workflow_configs/saml_schema.py
+++ b/libs/superagent/app/api/workflow_configs/saml_schema.py
@@ -3,6 +3,8 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field, validator
 
+from prisma.enums import LLMProvider
+
 
 class SuperragEncoderType(str, Enum):
     openai = "openai"
@@ -95,7 +97,7 @@ class Assistant(BaseModel):
 # ~~~Agents~~~
 class SuperagentAgent(Assistant):
     tools: Optional[Tools]
-    data: Optional[Data]  # deprecated, use superrag instead
+    data: Optional[Data] = Field(description="Deprecated! Use `superrag` instead.")
     superrag: Optional[Superrag]
 
 
@@ -128,11 +130,21 @@ class LLMAgentTool(BaseAgentToolModel, LLMAgent):
 # for assistant as tools
 ToolModel.update_forward_refs()
 
+SAML_OSS_LLM_PROVIDERS = [
+    LLMProvider.PERPLEXITY.value,
+    LLMProvider.TOGETHER_AI.value,
+]
+
 
 class Workflow(BaseModel):
     superagent: Optional[SuperagentAgent]
     openai_assistant: Optional[OpenAIAgent]
-    llm: Optional[LLMAgent]
+    # ~~OSS LLM providers~~
+    perplexity: Optional[LLMAgent]
+    together_ai: Optional[LLMAgent]
+    llm: Optional[LLMAgent] = Field(
+        description="Deprecated! Use LLM providers instead. e.g. `perplexity` or `together_ai`"
+    )
 
 
 class WorkflowConfigModel(BaseModel):


### PR DESCRIPTION
Example Usage 


```yaml
workflows:
  - perplexity:
      llm: perplexity/llama-2-70b-chat
      name: Browser assistant
      prompt: You're a helpful assistant

```