### PR TITLE
Add Langfuse `sdk_integration` arg

### DIFF
--- a/libs/superagent/app/api/agents.py
+++ b/libs/superagent/app/api/agents.py
@@ -417,6 +417,7 @@ async def invoke(
             public_key=langfuse_public_key,
             secret_key=langfuse_secret_key,
             host=langfuse_host,
+            sdk_integration="Superagent",
         )
         session_id = f"{agent_id}-{body.sessionId}" if body.sessionId else f"{agent_id}"
         trace = langfuse.trace(

--- a/libs/superagent/app/utils/callbacks.py
+++ b/libs/superagent/app/utils/callbacks.py
@@ -148,6 +148,7 @@ def get_session_tracker_handler(
             public_key=langfuse_public_key,
             secret_key=langfuse_secret_key,
             host=langfuse_host,
+            sdk_integration="Superagent",
         )
         trace_id = (
             f"{workflow_id}-{req_session_id}" if req_session_id else f"{workflow_id}"


### PR DESCRIPTION
## Summary

This constructor args helps to identify which events were ingested via the Superagent integration. Useful for debugging.

## Test plan

Nothing to test here, kwarg is available since at least langfuse python sdk [v2.6.0](https://github.com/langfuse/langfuse-python/releases/tag/v2.6.0). Superagent uses `^2.16.2`.