### PR TITLE
fix: running format and linting commands for existing files only

### DIFF
--- a/libs/superagent/lint-and-format.sh
+++ b/libs/superagent/lint-and-format.sh
@@ -3,6 +3,9 @@
 # getting changed files (only staged)
 changes=$(git diff --name-only --cached | grep '^libs/superagent.*\.py$' | sed 's|^libs/superagent/||')
 
+# Filter deleted files
+changes=$(echo "$changes" | while read -r file; do [ -e "$file" ] && echo "$file"; done)
+
 lint() {
     poetry run black $changes
     # sort imports 


### PR DESCRIPTION
## Summary

This PR makes `format` and `lint` commands to run for only existing files. If one deletes a file, we should not run these commands for that file.