### PR TITLE
Move integrations link to underneath Settings in sidebar

### DIFF
--- a/libs/ui/config/site.ts
+++ b/libs/ui/config/site.ts
@@ -49,11 +49,6 @@ export const siteConfig = {
       href: "/logs",
       icon: TbTerminal2,
     },
-    {
-      title: "Integrations",
-      href: "/integrations",
-      icon: TbPlug,
-    },
   ],
   footerNav: [
     {
@@ -65,6 +60,11 @@ export const siteConfig = {
       title: "Documentation",
       href: "https://docs.superagent.sh",
       icon: TbFileCode,
+    },
+    {
+      title: "Integrations",
+      href: "/integrations",
+      icon: TbPlug,
     },
     {
       title: "Settings",


### PR DESCRIPTION
## Description

This PR moves the "Integrations" link from the main navigation section in the left-hand sidebar to the footer navigation section, placing it right before the "Settings" link.

## Changes

- Removed the "Integrations" entry from the `mainNav` array in `siteConfig`
- Added the "Integrations" entry to the `footerNav` array, positioning it before the "Settings" link

## Visual Changes

Before:
```
Main Nav:
- Workflows
- Agents
- Logs
- Integrations

Footer Nav:
- Discord
- Documentation
- Settings
```

After:
```
Main Nav:
- Workflows
- Agents
- Logs

Footer Nav:
- Discord
- Documentation
- Integrations
- Settings
```

This change improves the sidebar organization by grouping the Integrations link with Settings, which is a more logical placement as both are related to system configuration.