### PR TITLE
Removed outdated terms from Docs

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -9,7 +9,7 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: 'Superagent',
-  description: 'AI Firewall Documentation',
+  description: 'Superagent Documentation',
   icons: {
     icon: [
       { url: '/favicon-16x16.png', sizes: '16x16', type: 'image/png' },

--- a/docs/content/docs/deployment.mdx
+++ b/docs/content/docs/deployment.mdx
@@ -1,9 +1,9 @@
 ---
 title: Deployment
-description: Deploy Superagent AI firewall using Docker, Node.js, or Rust
+description: Deploy Superagent as a hosted API or self-hosted in your infrastructure
 ---
 
-Superagent provides multiple deployment options to suit different environments and performance requirements. Choose the method that best fits your infrastructure needs.
+Superagent provides flexible deployment options to suit different security, compliance, and infrastructure requirements. All deployment options provide the same Guard, Verify, and Redact capabilities with consistent APIs.
 
 ## Docker Deployment (Recommended)
 
@@ -15,7 +15,7 @@ cd superagent
 docker-compose up -d
 ```
 
-This will start the Superagent firewall with all necessary dependencies.
+This will start Superagent with all necessary dependencies.
 
 ## Node.js Deployment
 
@@ -87,4 +87,4 @@ Once deployed, Superagent automatically provides:
 - **Performance**: Rust deployment recommended for high-throughput environments
 - **Scaling**: Docker deployment supports horizontal scaling with orchestration platforms
 
-Your Superagent proxy URL will be available at the configured endpoint (typically `http://localhost:8080`) and can be used as the base URL in your AI client configurations.
+Your Superagent API URL will be available at the configured endpoint (typically `http://localhost:8080`) and can be used as the base URL in your AI client configurations.

--- a/docs/public/site.webmanifest
+++ b/docs/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
     "name": "Superagent",
     "short_name": "Superagent",
-    "description": "AI Firewall Documentation",
+    "description": "Superagent Documentation",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION

## Description
All outdated references to "Proxy", "Proxy URL", and "Firewall" terminology have been updated to align with current product positioning focusing on Superagent's Guard, Verify, and Redact capabilities accessed via API.

## Related Issue
Fixes #<issue number>

## Checklist
- [x] I tested my changes
- [x] I reviewed my own code