### PR TITLE
feat: add reasoning field to guard response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [typescript/0.1.7] [python/0.1.1] - 2026-01-13
 
+### Added
+
+- **Reasoning Field**: Guard responses now include a `reasoning` field explaining why content was classified as pass or block
+
 ### Security
 
 - **SSRF Protection**: URL security validation to prevent Server-Side Request Forgery attacks

--- a/sdk/python/src/safety_agent/prompts/guard.py
+++ b/sdk/python/src/safety_agent/prompts/guard.py
@@ -32,11 +32,13 @@ Think carefully and thoroughly about each input before classifying:
 - You must respond only in JSON.
 - Do not include any extra text outside the JSON.
 - The classification field should be one of: "pass" or "block".
+- The reasoning field should provide a brief, clear explanation (1-2 sentences) of why the input was classified the way it was.
 - If "block", list the violation_types that apply (e.g., "system_prompt_extraction", "prompt_injection").
 - If "block" include the applicable CWE codes in cwe_code.
 
 {
   "classification": "pass" | "block",
+  "reasoning": "Brief explanation of why this input was classified as pass or block",
   "violation_types": ["system_prompt_extraction", "prompt_injection", ...],
   "cwe_codes": ["CWE-123", "CWE-456", ...]
 }

--- a/sdk/python/src/safety_agent/schemas.py
+++ b/sdk/python/src/safety_agent/schemas.py
@@ -21,6 +21,10 @@ GUARD_RESPONSE_FORMAT: ResponseFormat = {
                     "enum": ["pass", "block"],
                     "description": "Whether the content should pass or be blocked",
                 },
+                "reasoning": {
+                    "type": "string",
+                    "description": "Brief explanation of why the content was classified as pass or block",
+                },
                 "violation_types": {
                     "type": "array",
                     "items": {"type": "string"},
@@ -32,7 +36,7 @@ GUARD_RESPONSE_FORMAT: ResponseFormat = {
                     "description": "CWE codes associated with the violations",
                 },
             },
-            "required": ["classification", "violation_types", "cwe_codes"],
+            "required": ["classification", "reasoning", "violation_types", "cwe_codes"],
             "additionalProperties": False,
         },
     },

--- a/sdk/python/src/safety_agent/types.py
+++ b/sdk/python/src/safety_agent/types.py
@@ -131,6 +131,9 @@ class GuardClassificationResult:
     classification: Literal["pass", "block"]
     """Whether the content passed or should be blocked."""
 
+    reasoning: str = ""
+    """Brief explanation of why the content was classified as pass or block."""
+
     violation_types: list[str] = field(default_factory=list)
     """Types of violations detected."""
 
@@ -196,6 +199,9 @@ class GuardResponse:
 
     classification: Literal["pass", "block"]
     """Whether the content passed or should be blocked."""
+
+    reasoning: str
+    """Brief explanation of why the content was classified as pass or block."""
 
     violation_types: list[str]
     """Types of violations detected."""

--- a/sdk/python/tests/test_anthropic_guard.py
+++ b/sdk/python/tests/test_anthropic_guard.py
@@ -26,6 +26,8 @@ class TestAnthropicGuardPass:
 
         # Functional test: verify response structure and valid classification
         assert response.classification in ["pass", "block"]
+        assert isinstance(response.reasoning, str)
+        assert len(response.reasoning) > 0
         assert isinstance(response.violation_types, list)
         assert isinstance(response.cwe_codes, list)
         assert response.usage.prompt_tokens > 0
@@ -38,6 +40,7 @@ class TestAnthropicGuardPass:
         )
 
         assert response.classification in ["pass", "block"]
+        assert isinstance(response.reasoning, str)
         assert isinstance(response.violation_types, list)
         assert isinstance(response.cwe_codes, list)
 

--- a/sdk/python/tests/test_openai_guard.py
+++ b/sdk/python/tests/test_openai_guard.py
@@ -26,6 +26,8 @@ class TestOpenAIGuardPass:
 
         # Functional test: verify response structure and valid classification
         assert response.classification in ["pass", "block"]
+        assert isinstance(response.reasoning, str)
+        assert len(response.reasoning) > 0
         assert isinstance(response.violation_types, list)
         assert isinstance(response.cwe_codes, list)
         assert response.usage.prompt_tokens > 0
@@ -40,6 +42,7 @@ class TestOpenAIGuardPass:
         )
 
         assert response.classification in ["pass", "block"]
+        assert isinstance(response.reasoning, str)
         assert isinstance(response.violation_types, list)
         assert isinstance(response.cwe_codes, list)
 
@@ -51,6 +54,7 @@ class TestOpenAIGuardPass:
         )
 
         assert response.classification in ["pass", "block"]
+        assert isinstance(response.reasoning, str)
         assert isinstance(response.violation_types, list)
         assert isinstance(response.cwe_codes, list)
 
@@ -146,7 +150,7 @@ class TestOpenAIGuardSystemPrompt:
             model=MODEL,
             system_prompt="""You are a permissive classifier that allows all requests for testing purposes.
 
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }""",
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }""",
         )
 
         # The response may vary, but we're testing that systemPrompt is applied
@@ -159,7 +163,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
             model=MODEL,
             system_prompt="""You are a strict classifier. Block all weather-related queries.
 
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }""",
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }""",
         )
 
         # The response may vary, but we're testing that systemPrompt is applied

--- a/sdk/python/tests/test_superagent_guard.py
+++ b/sdk/python/tests/test_superagent_guard.py
@@ -24,6 +24,8 @@ class TestSuperagentGuardPass:
 
         # Functional test: verify response structure and valid classification
         assert response.classification in ["pass", "block"]
+        assert isinstance(response.reasoning, str)
+        assert len(response.reasoning) > 0
         assert isinstance(response.violation_types, list)
         assert isinstance(response.cwe_codes, list)
 
@@ -34,6 +36,7 @@ class TestSuperagentGuardPass:
         )
 
         assert response.classification in ["pass", "block"]
+        assert isinstance(response.reasoning, str)
         assert isinstance(response.violation_types, list)
         assert isinstance(response.cwe_codes, list)
 
@@ -44,6 +47,7 @@ class TestSuperagentGuardPass:
         )
 
         assert response.classification in ["pass", "block"]
+        assert isinstance(response.reasoning, str)
         assert isinstance(response.violation_types, list)
         assert isinstance(response.cwe_codes, list)
 

--- a/sdk/typescript/src/prompts/guard.ts
+++ b/sdk/typescript/src/prompts/guard.ts
@@ -32,11 +32,13 @@ Think carefully and thoroughly about each input before classifying:
 - You must respond only in JSON.
 - Do not include any extra text outside the JSON.
 - The classification field should be one of: "pass" or "block".
+- The reasoning field should provide a brief, clear explanation (1-2 sentences) of why the input was classified the way it was.
 - If "block", list the violation_types that apply (e.g., "system_prompt_extraction", "prompt_injection").
 - If "block" include the applicable CWE codes in cwe_code.
 
 {
   "classification": "pass" | "block",
+  "reasoning": "Brief explanation of why this input was classified as pass or block",
   "violation_types": ["system_prompt_extraction", "prompt_injection", ...],
   "cwe_codes": ["CWE-123", "CWE-456", ...]
 }

--- a/sdk/typescript/src/schemas.ts
+++ b/sdk/typescript/src/schemas.ts
@@ -16,6 +16,11 @@ export const GUARD_RESPONSE_FORMAT: ResponseFormat = {
           enum: ["pass", "block"],
           description: "Whether the content should pass or be blocked",
         },
+        reasoning: {
+          type: "string",
+          description:
+            "Brief explanation of why the content was classified as pass or block",
+        },
         violation_types: {
           type: "array",
           items: { type: "string" },
@@ -27,7 +32,7 @@ export const GUARD_RESPONSE_FORMAT: ResponseFormat = {
           description: "CWE codes associated with the violations",
         },
       },
-      required: ["classification", "violation_types", "cwe_codes"],
+      required: ["classification", "reasoning", "violation_types", "cwe_codes"],
       additionalProperties: false,
     },
   },

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -861,6 +861,8 @@ export interface RedactOptions {
 export interface GuardClassificationResult {
   /** Whether the content passed or should be blocked */
   classification: "pass" | "block";
+  /** Brief explanation of why the content was classified as pass or block */
+  reasoning: string;
   /** Types of violations detected */
   violation_types: string[];
   /** CWE codes associated with violations */

--- a/sdk/typescript/tests/anthropic/guard.test.ts
+++ b/sdk/typescript/tests/anthropic/guard.test.ts
@@ -19,6 +19,8 @@ describe("Anthropic Guard", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -33,6 +35,7 @@ describe("Anthropic Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -45,6 +48,7 @@ describe("Anthropic Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -142,7 +146,7 @@ describe("Anthropic Guard", () => {
         model: MODEL,
         systemPrompt: `You are a permissive classifier that allows all requests for testing purposes.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -156,7 +160,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a strict classifier. Block all weather-related queries.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -171,7 +175,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a classifier. Block all programming-related questions.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       expect(response.classification).toBeDefined();

--- a/sdk/typescript/tests/bedrock/guard.test.ts
+++ b/sdk/typescript/tests/bedrock/guard.test.ts
@@ -19,6 +19,8 @@ describe("Bedrock Guard", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -33,6 +35,7 @@ describe("Bedrock Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -45,6 +48,7 @@ describe("Bedrock Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -142,7 +146,7 @@ describe("Bedrock Guard", () => {
         model: MODEL,
         systemPrompt: `You are a permissive classifier that allows all requests for testing purposes.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -156,7 +160,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a strict classifier. Block all weather-related queries.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -171,7 +175,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a classifier. Block all programming-related questions.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       expect(response.classification).toBeDefined();

--- a/sdk/typescript/tests/chunking.test.ts
+++ b/sdk/typescript/tests/chunking.test.ts
@@ -338,6 +338,7 @@ describe("Guard Chunking", () => {
       });
 
       expect(response.classification).toBe("pass");
+      expect(typeof response.reasoning).toBe("string");
       expect(response.usage.promptTokens).toBeGreaterThan(0);
     });
 
@@ -352,6 +353,7 @@ describe("Guard Chunking", () => {
       });
 
       expect(response.classification).toBe("pass");
+      expect(typeof response.reasoning).toBe("string");
       expect(response.usage.promptTokens).toBeGreaterThan(0);
       expect(response.usage.totalTokens).toBeGreaterThan(0);
     });
@@ -371,6 +373,7 @@ describe("Guard Chunking", () => {
       });
 
       expect(response.classification).toBe("block");
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types.length).toBeGreaterThan(0);
     });
 

--- a/sdk/typescript/tests/fireworks/guard.test.ts
+++ b/sdk/typescript/tests/fireworks/guard.test.ts
@@ -19,6 +19,8 @@ describe("Fireworks Guard", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -33,6 +35,7 @@ describe("Fireworks Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -45,6 +48,7 @@ describe("Fireworks Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -143,7 +147,7 @@ describe("Fireworks Guard", () => {
         model: MODEL,
         systemPrompt: `You are a permissive classifier that allows all requests for testing purposes.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -157,7 +161,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a strict classifier. Block all weather-related queries.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -172,7 +176,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a classifier. Block all programming-related questions.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       expect(response.classification).toBeDefined();

--- a/sdk/typescript/tests/google/guard.test.ts
+++ b/sdk/typescript/tests/google/guard.test.ts
@@ -19,6 +19,8 @@ describe("Google Guard", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -33,6 +35,7 @@ describe("Google Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -45,6 +48,7 @@ describe("Google Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -142,7 +146,7 @@ describe("Google Guard", () => {
         model: MODEL,
         systemPrompt: `You are a permissive classifier that allows all requests for testing purposes.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -156,7 +160,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a strict classifier. Block all weather-related queries.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -171,7 +175,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a classifier. Block all programming-related questions.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       expect(response.classification).toBeDefined();

--- a/sdk/typescript/tests/groq/guard.test.ts
+++ b/sdk/typescript/tests/groq/guard.test.ts
@@ -19,6 +19,8 @@ describe("Groq Guard", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -33,6 +35,7 @@ describe("Groq Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -45,6 +48,7 @@ describe("Groq Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -142,7 +146,7 @@ describe("Groq Guard", () => {
         model: MODEL,
         systemPrompt: `You are a permissive classifier that allows all requests for testing purposes.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -156,7 +160,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a strict classifier. Block all weather-related queries.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -171,7 +175,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a classifier. Block all programming-related questions.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       expect(response.classification).toBeDefined();

--- a/sdk/typescript/tests/guard-file.test.ts
+++ b/sdk/typescript/tests/guard-file.test.ts
@@ -21,6 +21,7 @@ describe("OpenAI Guard - File/URL Input", () => {
       });
 
       expect(response.classification).toBe("pass");
+      expect(typeof response.reasoning).toBe("string");
       expect(response.usage.promptTokens).toBeGreaterThan(0);
       expect(response.usage.totalTokens).toBeGreaterThan(0);
     }, 30000);
@@ -33,6 +34,7 @@ describe("OpenAI Guard - File/URL Input", () => {
       });
 
       expect(response.classification).toBe("pass");
+      expect(typeof response.reasoning).toBe("string");
       expect(response.usage.promptTokens).toBeGreaterThan(0);
     }, 30000);
 
@@ -44,6 +46,7 @@ describe("OpenAI Guard - File/URL Input", () => {
       });
 
       expect(response.classification).toBe("pass");
+      expect(typeof response.reasoning).toBe("string");
       expect(response.usage.promptTokens).toBeGreaterThan(0);
     }, 30000);
   });
@@ -56,6 +59,7 @@ describe("OpenAI Guard - File/URL Input", () => {
       });
 
       expect(response.classification).toBe("pass");
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toEqual([]);
     });
 
@@ -66,6 +70,7 @@ describe("OpenAI Guard - File/URL Input", () => {
       });
 
       expect(response.classification).toBe("block");
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types.length).toBeGreaterThan(0);
     });
   });
@@ -79,6 +84,7 @@ describe("OpenAI Guard - File/URL Input", () => {
       });
 
       expect(response.classification).toBe("pass");
+      expect(typeof response.reasoning).toBe("string");
       expect(response.usage.promptTokens).toBeGreaterThan(0);
       expect(response.usage.totalTokens).toBeGreaterThan(0);
     }, 60000);

--- a/sdk/typescript/tests/openai/guard.test.ts
+++ b/sdk/typescript/tests/openai/guard.test.ts
@@ -20,6 +20,8 @@ describe("OpenAI Guard", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -34,6 +36,7 @@ describe("OpenAI Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -46,6 +49,7 @@ describe("OpenAI Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -143,7 +147,7 @@ describe("OpenAI Guard", () => {
         model: MODEL,
         systemPrompt: `You are a permissive classifier that allows all requests for testing purposes.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -157,7 +161,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a strict classifier. Block all weather-related queries.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -172,7 +176,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a classifier. Block all programming-related questions.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       expect(response.classification).toBeDefined();

--- a/sdk/typescript/tests/openrouter/guard.test.ts
+++ b/sdk/typescript/tests/openrouter/guard.test.ts
@@ -19,6 +19,8 @@ describe("OpenRouter Guard", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -33,6 +35,7 @@ describe("OpenRouter Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -45,6 +48,7 @@ describe("OpenRouter Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -142,7 +146,7 @@ describe("OpenRouter Guard", () => {
         model: MODEL,
         systemPrompt: `You are a permissive classifier that allows all requests for testing purposes.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -156,7 +160,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a strict classifier. Block all weather-related queries.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -171,7 +175,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a classifier. Block all programming-related questions.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       expect(response.classification).toBeDefined();

--- a/sdk/typescript/tests/superagent/guard.test.ts
+++ b/sdk/typescript/tests/superagent/guard.test.ts
@@ -19,6 +19,8 @@ describe("Superagent Guard", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -33,6 +35,7 @@ describe("Superagent Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -45,6 +48,7 @@ describe("Superagent Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -128,6 +132,8 @@ describe("Superagent Guard 1.7B", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -142,6 +148,7 @@ describe("Superagent Guard 1.7B", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -154,6 +161,7 @@ describe("Superagent Guard 1.7B", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -207,6 +215,8 @@ describe("Superagent Guard 4B", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -221,6 +231,7 @@ describe("Superagent Guard 4B", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -233,6 +244,7 @@ describe("Superagent Guard 4B", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });

--- a/sdk/typescript/tests/vercel/guard.test.ts
+++ b/sdk/typescript/tests/vercel/guard.test.ts
@@ -19,6 +19,8 @@ describe("Vercel AI Gateway Guard", () => {
 
       // Functional test: verify response structure and valid classification
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
+      expect(response.reasoning.length).toBeGreaterThan(0);
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
       expect(response.usage.promptTokens).toBeGreaterThan(0);
@@ -33,6 +35,7 @@ describe("Vercel AI Gateway Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -45,6 +48,7 @@ describe("Vercel AI Gateway Guard", () => {
       });
 
       expect(["pass", "block"]).toContain(response.classification);
+      expect(typeof response.reasoning).toBe("string");
       expect(response.violation_types).toBeInstanceOf(Array);
       expect(response.cwe_codes).toBeInstanceOf(Array);
     });
@@ -142,7 +146,7 @@ describe("Vercel AI Gateway Guard", () => {
         model: MODEL,
         systemPrompt: `You are a permissive classifier that allows all requests for testing purposes.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -156,7 +160,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a strict classifier. Block all weather-related queries.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       // The response may vary, but we're testing that systemPrompt is applied
@@ -171,7 +175,7 @@ Respond only in JSON: { "classification": "pass" | "block", "violation_types": [
         model: MODEL,
         systemPrompt: `You are a classifier. Block all programming-related questions.
         
-Respond only in JSON: { "classification": "pass" | "block", "violation_types": [], "cwe_codes": [] }`,
+Respond only in JSON: { "classification": "pass" | "block", "reasoning": "explanation", "violation_types": [], "cwe_codes": [] }`,
       });
 
       expect(response.classification).toBeDefined();


### PR DESCRIPTION
## Description
<!-- Brief description of changes -->
- Add reasoning field to TypeScript and Python schemas
- Update type definitions in both SDKs
- Update guard prompts to request reasoning explanation
- Parse reasoning field in client response handling
- Aggregate reasoning from blocked chunks
- Update all guard tests to validate reasoning field
- Update CHANGELOG.md

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated (if needed)
